### PR TITLE
move keep_ambiguous from yml to sos parameter

### DIFF
--- a/pipeline/misc/summary_stats_merger.ipynb
+++ b/pipeline/misc/summary_stats_merger.ipynb
@@ -61,7 +61,8 @@
     "## Input\n",
     "\n",
     "- `--cwd`, the path of output directory\n",
-    "- `--yml_path`, the path of yaml file"
+    "- `--yml_path`, the path of yaml file\n",
+    "- `--keep_ambiguous`, bool. if Ture, keep ambiguous alleles which can not be decided from flip or reverse, such as A/T or C/G. Otherwise, remove them."
    ]
   },
   {
@@ -105,7 +106,6 @@
     "        SE: SE\n",
     "        P: P\n",
     "OUTPUT: data/testflip/output/\n",
-    "KEEP_AMBIGUOUS: True\n",
     "```"
    ]
   },
@@ -126,12 +126,7 @@
     "- TARGET\n",
     "   - the reference summary statistic file, which the other files compare with.\n",
     "- OUTPUT\n",
-    "   - the path of an output directory for new summary statistic files\n",
-    "   - for each input sumstat file, a qced version will be generated.\n",
-    "   - The generated sumstat files will have header as \"CHR  ,   POS  ,   A0   ,   A1    ,  SNP   ,  STAT ,   SE    ,  P\" regardless of input header\n",
-    "   - The generated sumstat files will be in gz format.\n",
-    "- KEEP_AMBIGUOUS\n",
-    "   - if Ture, keep ambiguous alleles which can not be decided from flip or reverse, such as A/T or C/G. Otherwise, remove them."
+    "   - the path of an output directory for new summary statistic files"
    ]
   },
   {
@@ -164,7 +159,7 @@
    },
    "source": [
     "```\n",
-    "sos run ./summary_stats_merger.ipynb --cwd data --yml_path data/template.yml\n",
+    "sos run ./summary_stats_merger.ipynb --cwd data --yml_path data/template.yml --keep_ambiguous=True\n",
     "```"
    ]
   },
@@ -186,6 +181,8 @@
     "yml_path = pd.read_csv(yml_list,sep = \"\\t\").values.tolist()\n",
     "# Path to work directory where the yaml file locates\n",
     "#parameter: yml_path = path(\".\")\n",
+    "#if Ture, keep ambiguous alleles which can not be decided from flip or reverse, such as A/T or C/G. Otherwise, remove them.\n",
+    "parameter: keep_ambiguous = str\n",
     "# Containers that contains the necessary packages\n",
     "#parameter: container = 'gaow/twas'"
    ]
@@ -219,13 +216,13 @@
     "    import pandas as pd\n",
     "    from Bio.Seq import Seq\n",
     "\n",
-    "    def merge_sumstats(yml):\n",
+    "    def merge_sumstats(yml,keep_ambiguous):\n",
     "        #parse yaml\n",
     "        yml = load_yaml(yml)\n",
     "        input_dict = parse_input(yml['INPUT'])\n",
     "        target_dict = parse_input(yml['TARGET'])\n",
     "        output_path = yml['OUTPUT']\n",
-    "        keep_ambiguous = yml['KEEP_AMBIGUOUS']\n",
+    "        \n",
     "        input_dict[list(target_dict.keys())[0]] = list(target_dict.values())[0]\n",
     "        lst_sumstats_file = [os.path.basename(i) for i in input_dict.keys()]\n",
     "        print('Total number of sumstats: ',len(lst_sumstats_file))\n",
@@ -330,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "3e63b670-435a-44ea-91a4-4a754dd2fe2a",
    "metadata": {
     "kernel": "SoS"
@@ -341,10 +338,22 @@
     "depends: f'{cwd:a}/utils.py'\n",
     "input: for_each = \"yml_path\"\n",
     "python: expand = '${ }', input = f'{cwd:a}/utils.py', stderr = f'{cwd:a}/output.stderr', stdout = f'{cwd:a}/output.stdout'\n",
+    "\n",
     "    yml = \"${_yml_path[1]}\"\n",
-    "    print(yml)\n",
-    "    merge_sumstats(yml)"
+    "    keep_ambiguous = ${keep_ambiguous}\n",
+    "    print(yml, keep_ambiguous)\n",
+    "    merge_sumstats(yml, keep_ambiguous)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bacf21e4-7115-469a-bdcc-728cb8580632",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -370,7 +379,7 @@
      ""
     ]
    ],
-   "version": "0.22.6"
+   "version": "0.22.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I don't understand why we need to read multiple YAML files in the input parameter.
```
import pandas as pd
yml_path = pd.read_csv(yml_list,sep = "\t").values.tolist()
```
If there are multiple inputs in different formats or different folders, we can just put them in one YAML file.