### PR TITLE
RSEM result generated

### DIFF
--- a/pipeline/data_preprocessing/phenotype/normalization.ipynb
+++ b/pipeline/data_preprocessing/phenotype/normalization.ipynb
@@ -147,7 +147,13 @@
     "tags": []
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "[collapse]\n",
+    "input: annotation_gtf\n",
+    "output: f'{wd}/{_input:bn}.collapsed.gtf'\n",
+    "bash: expand = \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container = container\n",
+    "    python3 ${script_dir}/collapse_annotation.py ${_input} ${_output}"
+   ]
   },
   {
    "cell_type": "code",
@@ -160,7 +166,7 @@
    "source": [
     "[Normalization]\n",
     "# Path to the input molecular phenotype data, should be a processd and indexed bed.gz file, with tabix index.\n",
-    "input: counts_gct,tpm_gct,annotation_gtf\n",
+    "input: counts_gct,tpm_gct,output_from(\"collapse\")\n",
     "output: f'{wd}/{name}.mol_phe.bed.gz',  # For factor\n",
     "task: trunk_workers = 1, trunk_size = 1, walltime = '4h',  mem = '20G', tags = f'{step_name}_{_output[0]:bn}'  \n",
     "bash: expand = \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container = container\n",

--- a/pipeline/data_preprocessing/phenotype_preprocessing.ipynb
+++ b/pipeline/data_preprocessing/phenotype_preprocessing.ipynb
@@ -36,7 +36,7 @@
    "outputs": [],
    "source": [
     "cd /mnt/mfs/statgen/xqtl_workflow_testing/module/normailzation\n",
-    "sos run /home/hs3163/GIT/xqtl-pipeline/pipeline/data_preprocessing/phenotype/normalization.ipynb Normalization  \\\n",
+    "sos run /home/hs3163/GIT/xqtl-pipeline/pipeline/data_preprocessing/phenotype/normalization.ipynb collapse  \\\n",
     "--counts_gct \"./geneCounts.gct\"         --tpm_gct \"./geneTpm.gct\"        \\\n",
     "--vcf_chr_list \"/mnt/mfs/statgen/xqtl_workflow_testing/expression_normalization/vcf_chrom_list\"     \\\n",
     "--sample_participant_lookup \"/mnt/mfs/statgen/xqtl_workflow_testing/expression_normalization/sampleSheetAfterQc.txt\"      \\\n",

--- a/pipeline/molecular_phenotypes/Reference_processing.ipynb
+++ b/pipeline/molecular_phenotypes/Reference_processing.ipynb
@@ -60,7 +60,7 @@
     "# Number of threads\n",
     "parameter: numThreads = 8\n",
     "# Software container option\n",
-    "parameter: container = \"/mnt/mfs/statgen/containers/xqtl_pipeline_sif/rna_quantification.sif\"\n"
+    "parameter: container = \"\"\n"
    ]
   },
   {
@@ -81,9 +81,37 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "04a51056-2ceb-4598-b5ee-b8e8d30ec8d1",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### GTF reformatting"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6271038a-d831-4fe2-b5e7-0d841655452e",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "This step modify the gtf file for following reason:\n",
+    "1. RSEM require GTF input to have the same chromosome name format as the fasta file.\n",
+    "\n",
+    "**For STAR, this problem can be solved by the now commented --sjdbGTFchrPrefix \"chr\"  option**\n",
+    "   \n",
+    "2. collapse_annotation.py from GTEX require the gtf have transcript_type insteadd transcript_biotype in its annotation.\n",
+    "**This problem can be solved by modifying the collapse_annotation.py while building the docker**\n",
+    "\n",
+    "Once the problem with RSEM is solved, or when RSEM is no longer needed, the aforementioned remedy can be implemented and this step can be remvoed"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ad9852a-ef74-4560-9275-660ff8b95367",
+   "id": "32941265-117a-4e3b-b609-ddafa95b100d",
    "metadata": {
     "kernel": "SoS"
    },
@@ -93,20 +121,23 @@
     "# Reference genome\n",
     "parameter: gtf = path\n",
     "parameter: fasta = path\n",
+    "parameter: empty_rows = 5\n",
     "input: fasta, gtf\n",
-    "output:  f'{wd}/{_input:bn}.reformated.gtf'\n",
-    "R: expand = \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container = container\n",
+    "output:  f'{wd}/{_input[1]:bn}.reformated.gtf'\n",
+    "task: trunk_workers = 1, trunk_size = 1, walltime = '24h',  mem = '30G', tags = f'{step_name}_{_output[0]:bn}'\n",
+    "R: expand = \"${ }\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
     "    library(\"readr\")\n",
     "    library(\"stringr\")\n",
     "    library(\"dplyr\")\n",
     "    fasta = system(\"head -1 ${_input[0]}\",intern = TRUE)\n",
-    "    gtf = read_delim(\"${_input[1]}\", col_names  = F,\"\\t\")\n",
+    "    gtf = read_delim(\"${_input[1]}\", col_names  = F,\"\\t\", skip = ${empty_rows})\n",
     "    if(!str_detect(fasta,\">chr\")){\n",
     "    gtf_mod = gtf%>%mutate(X1 = str_remove_all(X1,\"chr\"))\n",
-    "    } else if(!str_detect(gtf$X1,\"chr\")) {\n",
+    "    } else if(!any(str_detect(gtf$X1[1],\"chr\"))) {\n",
     "        gtf_mod = gtf%>%mutate(X1 = paste0(\"chr\",X1))    \n",
     "    }\n",
-    "    gtf_mod%>%write_delim(\"${_output}\",delim = \"\\t\",col_names = F)"
+    "    if(str_detect(gtf_mod$X9,\"transcript_biotype\")){gtf_mod = gtf_mod%>%mutate(X9 = str_replace_all(X9,\"transcript_biotype\",\"transcript_type\"))}\n",
+    "    gtf_mod%>%write.table(\"${_output}\",sep = \"\\t\",quote = FALSE,col.names = F,row.names = F)"
    ]
   },
   {
@@ -119,9 +150,9 @@
    "outputs": [],
    "source": [
     "[collapse]\n",
-    "parameter: gtf_file = path\n",
+    "parameter: gtf = path\n",
     "parameter: script_dir = \"/mnt/mfs/statgen/xqtl_workflow_testing/expression_normalization/\"\n",
-    "input: gtf_file\n",
+    "input: gtf\n",
     "output: f'{wd}/{_input:bn}.collapsed.gtf'\n",
     "bash: expand = \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container = container\n",
     "    python ${script_dir}/collapse_annotation.py ${_input} ${_output}"
@@ -170,11 +201,11 @@
     "task: trunk_workers = 1, trunk_size = 1, walltime = '24h',  mem = '40G', tags = f'{step_name}_{_output[0]:bn}'\n",
     "bash: container=container, expand= \"${ }\", stderr = f'{_input[0]}.stderr', stdout = f'{_input[0]}.stdout'\n",
     "    STAR --runMode genomeGenerate \\\n",
-    "         --genomeDir ${_output} \\\n",
+    "         --genomeDir ${_output:d} \\\n",
     "         --genomeFastaFiles ${_input[0]} \\\n",
     "         --sjdbGTFfile ${_input[1]} \\\n",
     "         --sjdbOverhang ${sjdbOverhang} \\\n",
-    "         --runThreadN ${numThreads}"
+    "         --runThreadN ${numThreads} #--sjdbGTFchrPrefix \"chr\" "
    ]
   },
   {
@@ -214,7 +245,7 @@
     "parameter: fasta = path\n",
     "parameter: name = str\n",
     "input: fasta, gtf\n",
-    "output: f'{wd}/RSEM_Index/{name}.idx.fa'\n",
+    "output: f'{wd}/RSEM_Index/rsem_reference.idx.fa'\n",
     "task: trunk_workers = 1, trunk_size = 1, walltime = '24h',  mem = '40G', tags = f'{step_name}_{_output[0]:bn}'\n",
     "bash: container=container, expand= \"${ }\", stderr = f'{_input[0]}.stderr', stdout = f'{_input[0]}.stdout'\n",
     "    rsem-prepare-reference \\\n",

--- a/pipeline/molecular_phenotypes/bulk_expression.ipynb
+++ b/pipeline/molecular_phenotypes/bulk_expression.ipynb
@@ -57,7 +57,7 @@
     "# Number of threads\n",
     "parameter: numThreads = 8\n",
     "# Software container option\n",
-    "parameter: container_rna_calling = \"/mnt/mfs/statgen/containers/xqtl_pipeline_sif/rna_quantification.sif\"\n",
+    "parameter: container = \"\"\n",
     "\n",
     "# Raw data:\n",
     "parameter: fastq1_raw = path\n",
@@ -236,11 +236,11 @@
    },
    "outputs": [],
    "source": [
-    "[RNA_qc]\n",
+    "[fastqc_report]\n",
     "input: for_each = \"fastq_raw\"\n",
     "output: f'{cwd}/{_fastq_raw:bnn}_fastqc.html',f'{cwd}/{_fastq_raw:bnn}_fastqc/fastqc_data.txt' \n",
     "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
-    "bash: expand= \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container=container_rna_calling\n",
+    "bash: expand= \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container=container\n",
     "    fastqc ${_fastq_raw} -o ${_output[0]:d}\n",
     "    unzip ${_output[0]:n}.zip"
    ]
@@ -293,7 +293,7 @@
     "        fq_2 = f'{wd}/{sample_id}_paired_{_input[1]:bn}.gz',\n",
     "        fq_2_up = f'{wd}/{sample_id}_unpaired_{_input[1]:bn}.gz'\n",
     "task: trunk_workers = 1, trunk_size = 1, walltime = '24h',  mem = '10G', tags = f'{step_name}_{_output[0]:bn}'\n",
-    "bash: container=container_rna_calling, expand= \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "bash: container=container, expand= \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
     "    java -jar ${soft_dir}/trimmomatic-0.39.jar PE -threads ${numThreads} \\\n",
     "                            ${_input[0]} \\\n",
     "                            ${_input[1]} \\\n",
@@ -348,7 +348,6 @@
    "outputs": [],
    "source": [
     "[STAR_align]\n",
-    "\n",
     "# STAR indexing file\n",
     "parameter: STAR_index = path\n",
     "# Alignment parameter\n",
@@ -375,14 +374,13 @@
     "parameter: chimOutType =  \"Junctions WithinBAM SoftClip\" \n",
     "parameter: chimMainSegmentMultNmax = 1 \n",
     "\n",
-    "\n",
     "input: output_from(\"Remove_adaptor\")[\"fq_1\"],output_from(\"Remove_adaptor\")[\"fq_2\"]\n",
     "output: cord_bam = f'{wd}/{sample_id}.Aligned.sortedByCoord.out.bam',\n",
     "        trans_bam = f'{wd}/{sample_id}.Aligned.toTranscriptome.out.bam'\n",
-    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
-    "bash: container=container_rna_calling, expand= \"${ }\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
     "\n",
-    "    python3 run_STAR.py \\\n",
+    "task: trunk_workers = 1, walltime = '24h', mem = \"40G\", cores = numThreads\n",
+    "bash: container=container, expand= \"${ }\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "    run_STAR.py \\\n",
     "        ${STAR_index} ${_input[0]} ${_input[1]} ${sample_id} \\\n",
     "        --output_dir ${wd} \\\n",
     "        --outFilterMultimapNmax ${outFilterMultimapNmax} \\\n",
@@ -452,7 +450,7 @@
     "[Picard_QC]\n",
     "input: output_from(\"STAR_align\")[\"cord_bam\"]\n",
     "output: f'{wd}/${sample_id}.Aligned.sortedByCoord.out.patched.md.bam'\n",
-    "bash: container=container_rna_calling, expand= \"${ }\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "bash: container=container, expand= \"${ }\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
     "        run_MarkDuplicates.py ${_input} ${sample_id}"
    ]
   },
@@ -504,7 +502,7 @@
     "parameter: gtf = path\n",
     "\n",
     "input: output_from(\"Picard_QC\")\n",
-    "bash: container=container_rna_calling, expand= \"${ }\"\n",
+    "bash: container=container, expand= \"${ }\"\n",
     "    python3 run_rnaseqc.py \\\n",
     "        ${gtf}\n",
     "        ${_input} \\\n",
@@ -544,14 +542,17 @@
    "outputs": [],
    "source": [
     "[RSEM]\n",
+    "parameter: RSEM_index = path\n",
     "input: output_from(\"STAR_align\")[\"trans_bam\"]\n",
-    "bash: container=container_rna_calling, expand= \"${ }\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
-    "    python3 run_RSEM.py \\\n",
+    "output: f'{wd}/RSEM_output/final_log'\n",
+    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
+    "bash: container=container, expand= \"${ }\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "    run_RSEM.py \\\n",
     "        --max_frag_len 1000 \\\n",
     "        --estimate_rspd true \\\n",
     "        --is_stranded true \\\n",
     "        --threads ${numThreads} \\\n",
-    "        ${RSEM_index} ${_input} ${sample_id}"
+    "        ${RSEM_index} ${_input:a} ${sample_id} -o ${_output:d}"
    ]
   }
  ],


### PR DESCRIPTION
current status:
1. RSEM result can be generated with the RSEM/STAR index generated by old testing gtf/fa (i.e not the consortium one)
2. RSEM & STAR index can be generated by the reformatted consortium gtf/fa
3. collapse_annotation.py cant run with the reformatted gtf, with following warning message:
```
ValueError: invalid literal for int() with base 10: 2.3e+07
```
while 2.3e+07 did not present within the reformated gtf

still investigating

4. After 3 is fixed: add left over script to docker as #97 
5. test the Picard_QC/RNA_QC module
6. output modification for RSEM

