### PR TITLE
sample merger & readcount_QC NA warning done

### DIFF
--- a/pipeline/data_preprocessing/phenotype/normalization.ipynb
+++ b/pipeline/data_preprocessing/phenotype/normalization.ipynb
@@ -193,7 +193,7 @@
     "          #  \" > $[_output[0]:r]\n",
     "    cp $[_output[0]:r] $[_output[1]:r]\n",
     "R: expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container = container\n",
-    "    library(\"tidyverse\")\n",
+    "    library(c(\"dplyr\",\"readr\"))\n",
     "    # Reason to use read.table: 1.accomodate both \" \" and \"\\t\"\n",
     "    tpm = read.table($[_input[0]:r],header = T)\n",
     "    geneCount = read.table($[_input[1]]:r],header = T)\n",

--- a/pipeline/misc/summary_stats_merger.ipynb
+++ b/pipeline/misc/summary_stats_merger.ipynb
@@ -333,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bacf21e4-7115-469a-bdcc-728cb8580632",
+   "id": "b4b7a158-76d8-47dd-9e31-eaf2236db85a",
    "metadata": {
     "kernel": "SoS"
    },

--- a/pipeline/molecular_phenotypes/QC/readcount_QC.ipynb
+++ b/pipeline/molecular_phenotypes/QC/readcount_QC.ipynb
@@ -38,7 +38,7 @@
    },
    "outputs": [],
    "source": [
-    "sos dryrun ~/GIT/xqtl-pipeline/pipeline/molecular_phenotype/readcount_QC.ipynb --TPM_file /mnt/mfs/statgen/xqtl_workflow_testing/expression_normalization/test_geneTpm.txt  "
+    "sos run ~/GIT/xqtl-pipeline/pipeline/molecular_phenotype/readcount_QC.ipynb --TPM_file /mnt/mfs/statgen/xqtl_workflow_testing/expression_normalization/test_geneTpm.txt  "
    ]
   },
   {

--- a/pipeline/molecular_phenotypes/QC/readcount_QC.ipynb
+++ b/pipeline/molecular_phenotypes/QC/readcount_QC.ipynb
@@ -38,12 +38,12 @@
    },
    "outputs": [],
    "source": [
-    "sos run ~/GIT/xqtl-pipeline/pipeline/molecular_phenotype/readcount_QC.ipynb --TPM_file /mnt/mfs/statgen/xqtl_workflow_testing/expression_normalization/test_geneTpm.txt  "
+    "sos dryrun ~/GIT/xqtl-pipeline/pipeline/molecular_phenotype/readcount_QC.ipynb --TPM_file /mnt/mfs/statgen/xqtl_workflow_testing/expression_normalization/test_geneTpm.txt  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "turned-insurance",
    "metadata": {
     "kernel": "SoS",
@@ -67,7 +67,9 @@
     "parameter: cluster_level = 5\n",
     "parameter: low_expr_TPM = 0.1\n",
     "parameter: low_expr_TPM_percent = 0.2\n",
-    "parameter: TPM_pseudo_count = 0.01"
+    "parameter: TPM_pseudo_count = 0.01\n",
+    "# Only genes with missingness below the treshold will be imputed\n",
+    "parameter: missing_treshold = 0.1"
    ]
   },
   {
@@ -119,6 +121,10 @@
     "      TPM_data = TPM_data[,-1]\n",
     "      loaded_sample_count <- ncol(TPM_data)\n",
     "    }\n",
+    "    #### NA check\n",
+    "    if(sum(is.na(TPM_data)) > 0 ){      \n",
+    "      print(\"NA is not allowed in the data, Exit!\")\n",
+    "      quit(save = \"no\", status = 1, runLast = FALSE)}\n",
     "    #### make sure every expr column is in numeric type\n",
     "    matrix_check <- map(TPM_data, is.numeric) %>% unlist\n",
     "    if(sum(!matrix_check) > 0){\n",
@@ -128,6 +134,9 @@
     "      }\n",
     "    print(\"Gene expression profiles loaded successfully!\")\n",
     "    print(paste(nrow(TPM_data), \"genes and\", ncol(TPM_data), \"samples are loaded from\", tpmfile, sep = \" \"))\n",
+    "    \n",
+    "\n",
+    "  \n",
     "    \n",
     "    #### Filter out low exp genes\n",
     "    keep_genes_idx <- (rowMeans(TPM_data>low_expr_TPM)>low_expr_TPM_percent) \n",
@@ -273,7 +282,7 @@
      "sos"
     ]
    ],
-   "version": "0.22.4"
+   "version": "0.22.6"
   }
  },
  "nbformat": 4,

--- a/pipeline/molecular_phenotypes/calling/RNA_calling.ipynb
+++ b/pipeline/molecular_phenotypes/calling/RNA_calling.ipynb
@@ -74,6 +74,7 @@
     "```\n",
     "sample_1 samp1_r1.fq.gz samp1_r2.fq.gz\n",
     "sample_2 samp2_r1.fq.gz samp2_r2.fq.gz\n",
+    "sample_3 samp3_r1.fq.gz samp3_r2.fq.gz\n",
     "```\n",
     "\n",
     "All the fastq files should be available under specified folder (default assumes the same folder as where the meta-data file is)."
@@ -158,6 +159,26 @@
     "    --container container/rna_quantification.sif \\\n",
     "    --mem 40G"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "804be5d9-8a50-4089-bdf9-d7595752172f",
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7e3d7be5-ecd9-4c70-8eb2-f8e36ccd3f11",
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -757,6 +778,48 @@
     "        --is_stranded ${\"true\" if is_stranded else \"false\"} \\\n",
     "        --threads ${numThreads}"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f6def9ad-fc07-4b1b-9635-8a98b7bd49ff",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[rnaseqc_call_5]\n",
+    "input: group_by = \"all\"\n",
+    "output: f'{cwd}/rnaseqc.gene_tpm.gct.gz',f'{cwd}/rnaseqc.gene_Count.gct.gz',f'{cwd}/rnaseqc.exon_Count.gct.gz'\n",
+    "python: container=container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
+    "    import pandas as pd\n",
+    "    def make_gct(gct_path):\n",
+    "        #sample_name\n",
+    "        sample_name = gct_path.split(\"/\")[-1].split(\".\")[0]\n",
+    "        #read_input\n",
+    "        pre_gct = pd.read_csv(gct_path,sep = \"\\t\",skiprows= 2,index_col=\"Name\").drop(\"Description\",axis = 1)\n",
+    "        pre_gct.index.name = \"gene_ID\"\n",
+    "        pre_gct.columns = [sample_name]\n",
+    "        return(pre_gct)\n",
+    "\n",
+    "    def merge_gct(gct_path_list):\n",
+    "        gct = pd.DataFrame()\n",
+    "        for gct_path in gct_path_list:\n",
+    "            #check duplicated indels and remove them.\n",
+    "            gct_col = make_gct(gct_path)\n",
+    "            gct = gct.merge(gct_col,right_index=True,left_index = True,how = \"outer\")\n",
+    "        return gct\n",
+    "    input_list = [${_input:r,}]\n",
+    "    tpm_list = input_list[0::3]\n",
+    "    gc_list = input_list[1::3]\n",
+    "    ec_list = input_list[2::3]\n",
+    "    gct_path_list_list = [tpm_list,gc_list,ec_list]\n",
+    "    output_path = [${_output:r,}]\n",
+    "    for i in range(0,len(output_path)):\n",
+    "        output = merge_gct(gct_path_list_list[i])\n",
+    "        output.to_csv(output_path[i], sep = \"\\t\")\n",
+    "    "
+   ]
   }
  ],
  "metadata": {
@@ -790,7 +853,7 @@
      "sos"
     ]
    ],
-   "version": "0.22.4"
+   "version": "0.22.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The output of rnaseqc sample merger can run within readcount_QC up to a point where mahalanobis  was calculated to identify outlier.
```
Error in solve.default(cov, ...) :
  Lapack routine dgesv: system is exactly singular: U[1,1] = 0
Calls: mahalanobis -> solve -> solve.default
Execution halted
```
The reason for this error is that there the three samples are too similar to each other, so that the covariance matrix of genes are all zero.

However, the fact that the output of readcount_QC can pass the data integrity check indicates that the merging is successful
