### PR TITLE
RSEM output aggregate

### DIFF
--- a/pipeline/molecular_phenotypes/calling/RNA_calling.ipynb
+++ b/pipeline/molecular_phenotypes/calling/RNA_calling.ipynb
@@ -187,7 +187,7 @@
     "    --STAR-index reference_data/STAR_Index/ \\\n",
     "    --RSEM-index reference_data/RSEM_Index/ \\\n",
     "    --container container/rna_quantification.sif \\\n",
-    "    --mem 40G --is_stranded True"
+    "    --mem 40G --is_paired_end &"
    ]
   },
   {
@@ -351,6 +351,8 @@
     "parameter: data_dir = path(f\"{samples:d}\")\n",
     "# Is the RNA-seq data stranded\n",
     "parameter: is_stranded = False\n",
+    "# Is the RNA-seq data pair-end\n",
+    "parameter: is_paired_end = False\n",
     "# For cluster jobs, number commands to run per job\n",
     "parameter: job_size = 1\n",
     "# Wall clock time expected\n",
@@ -827,7 +829,7 @@
     "        -o ${_output[0]:d} \\\n",
     "        --max_frag_len ${max_frag_len} \\\n",
     "        --estimate_rspd ${'true' if estimate_rspd else 'false'} \\\n",
-    "        --paired_end ${\"true\" if is_stranded else \"false\"} \\\n",
+    "        --paired_end ${\"true\" if is_paired_end else \"false\"} \\\n",
     "        --is_stranded ${\"true\" if is_stranded else \"false\"} \\\n",
     "        --threads ${numThreads}"
    ]

--- a/pipeline/molecular_phenotypes/calling/RNA_calling.ipynb
+++ b/pipeline/molecular_phenotypes/calling/RNA_calling.ipynb
@@ -187,8 +187,18 @@
     "    --STAR-index reference_data/STAR_Index/ \\\n",
     "    --RSEM-index reference_data/RSEM_Index/ \\\n",
     "    --container container/rna_quantification.sif \\\n",
-    "    --mem 40G"
+    "    --mem 40G --is_stranded True"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "599bea6e-e577-40db-9a2c-09beec8a1bd4",
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -353,6 +363,7 @@
     "parameter: container = \"\"\n",
     "from sos.utils import expand_size\n",
     "cwd = path(f'{cwd:a}')\n",
+    "\n",
     "\n",
     "def get_samples(fn, dr):\n",
     "    import os\n",
@@ -715,6 +726,64 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dd533f4-c308-4b2c-a3f9-dc54e258e82c",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "The RNASEQC results were merged in the following step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a2b8cf8-b9a1-4440-a86f-3fbbb610e61b",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[rnaseqc_call_5]\n",
+    "input: group_by = \"all\"\n",
+    "output: f'{cwd}/{samples:bn}.rnaseqc.gene_tpm.gct.gz',\n",
+    "        f'{cwd}/{samples:bn}.rnaseqc.gene_readsCount.gct.gz',\n",
+    "        f'{cwd}/{samples:bn}.rnaseqc.exon_readsCount.gct.gz'\n",
+    "python: container=container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
+    "    import pandas as pd\n",
+    "    import os\n",
+    "    def make_gct(gct_path):\n",
+    "        # sample_name\n",
+    "        sample_name = \".\".join(os.path.basename(gct_path).split(\".\")[:-4])\n",
+    "        # read_input\n",
+    "        pre_gct = pd.read_csv(gct_path,sep = \"\\t\",\n",
+    "                              skiprows= 2,index_col=\"Name\").drop(\"Description\",axis = 1)\n",
+    "        pre_gct.index.name = \"gene_ID\"\n",
+    "        pre_gct.columns = [sample_name]\n",
+    "        return(pre_gct)\n",
+    "\n",
+    "    def merge_gct(gct_path_list):\n",
+    "        gct = pd.DataFrame()\n",
+    "        for gct_path in gct_path_list:\n",
+    "            #check duplicated indels and remove them.\n",
+    "            gct_col = make_gct(gct_path)\n",
+    "            gct = gct.merge(gct_col,right_index=True,left_index = True,how = \"outer\")\n",
+    "        return gct\n",
+    "\n",
+    "    input_list = [${_input:r,}]\n",
+    "    tpm_list = input_list[0::3]\n",
+    "    gc_list = input_list[1::3]\n",
+    "    ec_list = input_list[2::3]\n",
+    "    gct_path_list_list = [tpm_list,gc_list,ec_list]\n",
+    "    output_path = [${_output:r,}]\n",
+    "    for i in range(0,len(output_path)):\n",
+    "        output = merge_gct(gct_path_list_list[i])\n",
+    "        output.to_csv(output_path[i], sep = \"\\t\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "regulation-scenario",
    "metadata": {
@@ -758,7 +827,7 @@
     "        -o ${_output[0]:d} \\\n",
     "        --max_frag_len ${max_frag_len} \\\n",
     "        --estimate_rspd ${'true' if estimate_rspd else 'false'} \\\n",
-    "        --is_pair_ended ${\"true\" if is_stranded else \"false\"} \\\n",
+    "        --paired_end ${\"true\" if is_stranded else \"false\"} \\\n",
     "        --is_stranded ${\"true\" if is_stranded else \"false\"} \\\n",
     "        --threads ${numThreads}"
    ]
@@ -770,7 +839,7 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Merge multi-sample results"
+    "The RSEM results were merged in the following steps, seven files (four for each columns in the isoform output and 3 for each of the genes output) will be generated."
    ]
   },
   {
@@ -782,42 +851,31 @@
    },
    "outputs": [],
    "source": [
-    "[rnaseqc_call_5]\n",
+    "[rsem_call_4]\n",
     "input: group_by = \"all\"\n",
-    "output: f'{cwd}/{samples:bn}.rnaseqc.gene_tpm.gct.gz',\n",
-    "        f'{cwd}/{samples:bn}.rnaseqc.gene_reads.gct.gz',\n",
-    "        f'{cwd}/{samples:bn}.rnaseqc.exon_reads.gct.gz'\n",
-    "python: container=container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
-    "    import pandas as pd\n",
-    "    import os\n",
-    "    def make_gct(gct_path):\n",
-    "        # sample_name\n",
-    "        sample_name = \".\".join(os.path.basename(gct_path).split(\".\")[:-4])\n",
-    "        # read_input\n",
-    "        pre_gct = pd.read_csv(gct_path,sep = \"\\t\",\n",
-    "                              skiprows= 2,index_col=\"Name\").drop(\"Description\",axis = 1)\n",
-    "        pre_gct.index.name = \"gene_ID\"\n",
-    "        pre_gct.columns = [sample_name]\n",
-    "        return(pre_gct)\n",
-    "\n",
-    "    def merge_gct(gct_path_list):\n",
-    "        gct = pd.DataFrame()\n",
-    "        for gct_path in gct_path_list:\n",
-    "            #check duplicated indels and remove them.\n",
-    "            gct_col = make_gct(gct_path)\n",
-    "            gct = gct.merge(gct_col,right_index=True,left_index = True,how = \"outer\")\n",
-    "        return gct\n",
-    "\n",
-    "    input_list = [${_input:r,}]\n",
-    "    tpm_list = input_list[0::3]\n",
-    "    gc_list = input_list[1::3]\n",
-    "    ec_list = input_list[2::3]\n",
-    "    gct_path_list_list = [tpm_list,gc_list,ec_list]\n",
-    "    output_path = [${_output:r,}]\n",
-    "    for i in range(0,len(output_path)):\n",
-    "        output = merge_gct(gct_path_list_list[i])\n",
-    "        output.to_csv(output_path[i], sep = \"\\t\")"
+    "output: f'{cwd}/RSEM_merged/{samples:bn}.rsem_transcripts_expected_count.txt.gz',\n",
+    "        f'{cwd}/RSEM_merged/{samples:bn}.rsem_transcripts_tpm.txt.gz',\n",
+    "        f'{cwd}/RSEM_merged/{samples:bn}.rsem_transcripts_fpkm.txt.gz',\n",
+    "        f'{cwd}/RSEM_merged/{samples:bn}.rsem_transcripts_isopct.txt.gz',\n",
+    "        f'{cwd}/RSEM_merged/{samples:bn}.rsem_genes_expected_count.txt.gz',\n",
+    "        f'{cwd}/RSEM_merged/{samples:bn}.rsem_genes_tpm.txt.gz',\n",
+    "        f'{cwd}/RSEM_merged/{samples:bn}.rsem_genes_fpkm.txt.gz'\n",
+    "bash: container=container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
+    "         ls ${_input[0]:d}/*.rsem.isoforms.results > rsem.isoforms_output_list\n",
+    "         ls ${_input[0]:d}/*.rsem.genes.results > rsem.genes_output_list\n",
+    "         aggregate_rsem_results.py rsem.isoforms_output_list  {expected_count,TPM,FPKM,IsoPct} ${_output[0]:nnn}\n",
+    "         aggregate_rsem_results.py rsem.genes_output_list  {expected_count,TPM,FPKM} ${_output[1]:nnn}"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83f15928-5f2d-48d7-b0b8-3717b44d5b20",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
 for the aggregate_rsem_result.py, it will produce 1 such file for all the genes&samples :
```
gene_id transcript_id(s)        samp1   samp2
gene:ENSG00000000003    transcript:ENST00000373020,transcript:ENST00000494424,transcript:ENST00000496771,transcript:ENST00000612152,transcript:ENST00000614008  0       0
gene:ENSG00000000005    transcript:ENST00000373031,transcript:ENST00000485971   0       0
gene:ENSG00000000419    transcript:ENST00000371582,transcript:ENST00000371584,transcript:ENST00000371588,transcript:ENST00000413082,transcript:ENST00000466152,transcript:ENST00000494752       0       0
```
for each of the columns in the rsem output.  Which I think defeat our purpose in archiving the results but may actually be easier for the group to use considering its similarity with bed/gct format 
