### PR TITLE
improvement of vcf_qc and fixes on bioinfo.sif dockerfile

### DIFF
--- a/container/docker/bioinfo.dockerfile
+++ b/container/docker/bioinfo.dockerfile
@@ -21,13 +21,21 @@ RUN cd /tmp && wget https://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_202
     unzip plink2_linux_avx2_20211217.zip && mv plink2 /usr/local/bin && rm -rf /tmp/plink2*
 RUN cd /tmp && wget https://cnsgenomics.com/software/gcta/bin/gcta_1.93.2beta.zip && \
     unzip gcta_1.93.2beta.zip && mv gcta_1.93.2beta/gcta64 /usr/local/bin && rm -rf /tmp/gcta*
-RUN #Install bcftools
+#Install bcftools, tabix, and bgzip
 RUN cd /tmp && wget https://github.com/samtools/bcftools/releases/download/1.12/bcftools-1.12.tar.bz2 -O bcftools.tar.bz2 && \
     tar -xjvf bcftools.tar.bz2 && \
     cd bcftools-1.12 && \
+    make prefix=/usr/local/bin install && \
+    ln -s /usr/local/bin/bin/bcftools /usr/bin/bcftools
+    
+RUN wget https://github.com/samtools/htslib/releases/download/1.12/htslib-1.12.tar.bz2 -O htslib-1.12.tar.bz2 && \
+    tar -xjvf htslib-1.12.tar.bz2 && \
+    cd htslib-1.12 && \
+    ./configure --prefix=/usr/local/bin && \
     make && \
-    make prefix=/usr/local install && \
-    rm -rf /tmp/bcftools*
+    make install && \
+    cp tabix bgzip htsfile /usr/local/bin
+    
 #Instal SnpEff that contains SnpSift
 RUN cd /tmp && wget https://snpeff.blob.core.windows.net/versions/snpEff_latest_core.zip && \
     unzip snpEff_latest_core.zip &&  \

--- a/container/singularity/bioinfo.def
+++ b/container/singularity/bioinfo.def
@@ -26,19 +26,25 @@ cd /tmp && wget https://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_2021121
 unzip plink2_linux_avx2_20211217.zip && mv plink2 /usr/local/bin && rm -rf /tmp/plink2*
 cd /tmp && wget https://cnsgenomics.com/software/gcta/bin/gcta_1.93.2beta.zip && \
 unzip gcta_1.93.2beta.zip && mv gcta_1.93.2beta/gcta64 /usr/local/bin && rm -rf /tmp/gcta*
-#Install bcftools
+#Install bcftools, tabix, and bgzip
 cd /tmp && wget https://github.com/samtools/bcftools/releases/download/1.12/bcftools-1.12.tar.bz2 -O bcftools.tar.bz2 && \
 tar -xjvf bcftools.tar.bz2 && \
 cd bcftools-1.12 && \
+make prefix=/usr/local/bin install && \
+ln -s /usr/local/bin/bin/bcftools /usr/bin/bcftools
+    
+wget https://github.com/samtools/htslib/releases/download/1.12/htslib-1.12.tar.bz2 -O htslib-1.12.tar.bz2 && \
+tar -xjvf htslib-1.12.tar.bz2 && \
+cd htslib-1.12 && \
+./configure --prefix=/usr/local/bin && \
 make && \
-make prefix=/usr/local install && \
-rm -rf /tmp/bcftools*
+make install && \
+cp tabix bgzip htsfile /usr/local/bin
+    
 #Instal SnpEff that contains SnpSift
 cd /tmp && wget https://snpeff.blob.core.windows.net/versions/snpEff_latest_core.zip && \
 unzip snpEff_latest_core.zip &&  \
 mv snpEff /opt && rm -rf /tmp/snpEff*
-
-
 
 %runscript
 exec /bin/bash exec /bin/bash "$@"

--- a/container/singularity/bioinfo.def
+++ b/container/singularity/bioinfo.def
@@ -34,6 +34,8 @@ make && \
 make prefix=/usr/local/bin install && \
 ln -s /usr/local/bin/bin/bcftools /usr/bin/bcftools
 
+
+
 %runscript
 exec /bin/bash exec /bin/bash "$@"
 %startscript

--- a/pipeline/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/pipeline/data_preprocessing/genotype/VCF_QC.ipynb
@@ -251,7 +251,7 @@
     "output: f\"{_input:nn}.variants.gz\"\n",
     "task: trunk_workers = 1, trunk_size=5, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
-    "    bcftools query  -f'%CHROM\\t%POS\\t%ID\\t%REF\\t%ALT\\n' ${_input} | \\\n",
+    "    bcftools query  -f'%CHROM\\t%POS\\t%ID\\t%REF\\t%ALT\\n' ${_input} && | \\\n",
     "        awk 'BEGIN{OFS=\"\\t\";} {if (length ($4) > length ($5)) {print $1,$2,$2+ (length ($4) - 1),$3} else {print $1,$2, $2 + (length ($4) -1 ),$3}}' | \\\n",
     "        bgzip -c > ${_output}"
    ]
@@ -417,7 +417,7 @@
      "sos"
     ]
    ],
-   "version": "0.22.4"
+   "version": "0.22.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
1. Fix the bioinfo dockerfile which lacked the tabix and bgzip tools
2. Add a mechanism in the VCF_QC so that, when bcftools query fails, the module will give an error message instead of empty output.