### PR TITLE
VCF_QC mwe done, actual analysis pending

### DIFF
--- a/code/data_preprocessing/genotype/GWAS_QC.ipynb
+++ b/code/data_preprocessing/genotype/GWAS_QC.ipynb
@@ -809,7 +809,7 @@
     "displayed": true,
     "height": 0
    },
-   "version": "0.22.4"
+   "version": "0.22.6"
   }
  },
  "nbformat": 4,

--- a/code/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/code/data_preprocessing/genotype/VCF_QC.ipynb
@@ -94,6 +94,7 @@
    "source": [
     "## Output\n",
     "1. a plink format genotype data \n",
+    "\n",
     "2. a set of sumstats/tstv data documenting the quality of vcf before and after qc"
    ]
   },
@@ -107,12 +108,12 @@
     "## Minimal working example\n",
     "The MWE is generated via \n",
     "```\n",
-    "bcftools query -l get-dosage.ALL.vcf.gz | head -40 > mwe_sample_list\n",
-    "bcftools view -S mwe_sample_list  get-dosage.ALL.vcf.gz > sample_filtered.vcf &\n",
+    "bcftools query -l get-dosage.ALL.vcf.gz | head -40 > MWE_sample_list\n",
+    "bcftools view -S MWE_sample_list  get-dosage.ALL.vcf.gz > sample_filtered.vcf &\n",
     "bgzip -c sample_filtered.vcf >  sample_filtered.vcf.gz\n",
     "tabix -p vcf sample_filtered.vcf.gz\n",
     "bcftools view --regions chr1 sample_filtered.vcf.gz > chr1_sample_filtered.vcf &\n",
-    "cat chr1_sample_filtered.vcf | head -20000 > mwe_genotype.vcf\n",
+    "cat chr1_sample_filtered.vcf | head -20000 > MWE_genotype.vcf\n",
     "```\n",
     "and was stored here: https://drive.google.com/file/d/1sxxPdPIyKma0mAl8TKwhgyRHlOh0Oyrc/view?usp=sharing"
    ]
@@ -127,17 +128,24 @@
     "The MWE was used as followed:\n",
     "\n",
     "```\n",
-    "sos run VCF_QC.ipynb dbsnp_annotate \\\n",
+    "sos run VCF_QC.ipynb rename_chrs \\\n",
     "    --genoFile reference_data/00-All.vcf.gz \\\n",
     "    --cwd reference_data --container ./bioinfo.sif\n",
     "```\n",
     "\n",
     "```\n",
+    "sos run VCF_QC.ipynb dbsnp_annotate \\\n",
+    "    --genoFile reference_data/00-All.add_chr.vcf.gz \\\n",
+    "    --cwd reference_data --container ./bioinfo.sif\n",
+    "```\n",
+    "\n",
+    "\n",
+    "```\n",
     "sos run VCF_QC.ipynb qc    \\\n",
-    "--genoFile data/mwe/mwe_genotype.vcf     \\\n",
+    "--genoFile data/MWE/MWE_genotype.vcf     \\\n",
     "--dbsnp-variants data/reference_data/00-All.add_chr.variants.gz  \\\n",
     "--reference-genome data/reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta   \\\n",
-    "--cwd mwe/output/genotype_1 --container ./bioinfo.sif -J 1 -c csg.yml -q csg  &\n",
+    "--cwd MWE/output/genotype_1 --container ./bioinfo.sif -J 1 -c csg.yml -q csg  &\n",
     "```\n",
     "To produce the following results:"
    ]
@@ -151,7 +159,17 @@
    "source": [
     "- Total TSTV for 19639 known variants before QC: 2.599\n",
     "- Total TSTV for 19573 known variants after QC: 2.600\n",
-    "- There is no novel variants included in the mwe."
+    "- There is no novel variants included in the MWE.\n",
+    "\n",
+    "The Total TS/TV is extracted from the output of qc_4 with following codes:\n",
+    "For known/novel variant before QC:\n",
+    "\n",
+    "`grep Ts/Tv {prefix of genoFile}*_variant.snipsift_tstv | rev | cut -d',' -f1 | rev`\n",
+    "\n",
+    "For known/novel variant after QC:\n",
+    "\n",
+    "`grep Ts/Tv {prefix of genoFile}*filtered.*_variant.snipsift_tstv | rev | cut -d',' -f1 | rev`\n",
+    "\n"
    ]
   },
   {
@@ -288,7 +306,6 @@
    "cell_type": "markdown",
    "id": "removable-extreme",
    "metadata": {
-    "jp-MarkdownHeadingCollapsed": true,
     "kernel": "SoS",
     "tags": []
    },
@@ -311,7 +328,7 @@
    },
    "outputs": [],
    "source": [
-    "[dbsnp_annotate_1]\n",
+    "[rename_chrs]\n",
     "# This file can be downloaded from https://ftp.ncbi.nlm.nih.gov/snp/organisms//human_9606_b150_GRCh38p7/VCF/00-All.vcf.gz.\n",
     "input: genoFile\n",
     "output: f\"{cwd}/{_input:bnn}.add_chr.vcf.gz\"\n",
@@ -323,8 +340,17 @@
     "    done    \n",
     "    bcftools annotate --rename-chrs chr_name_conv.txt ${_input} -Oz -o ${_output}\n",
     "    tabix -p vcf ${_output}\n",
-    "    rm chr_name_conv.txt\n",
-    "[dbsnp_annotate_2]\n",
+    "    rm chr_name_conv.txt\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2eb879d2-3868-4f47-9893-0e06dcd3222c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[dbsnp_annotate]\n",
     "output: f\"{_input:nn}.variants.gz\"\n",
     "task: trunk_workers = 1, trunk_size=5, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",

--- a/code/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/code/data_preprocessing/genotype/VCF_QC.ipynb
@@ -87,6 +87,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0651b0d2-0a93-4899-8817-e03fe2f701ec",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Output\n",
+    "1. a plink format genotype data \n",
+    "2. a set of sumstats/tstv data documenting the quality of vcf before and after qc"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "young-reflection",
    "metadata": {
     "kernel": "SoS"
@@ -106,13 +118,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "691cade1-0de8-4c66-a2ef-0c88ccff05af",
+   "cell_type": "markdown",
+   "id": "afbbef3b-e86d-458c-9732-bd2767c073e5",
    "metadata": {
     "kernel": "SoS"
    },
-   "outputs": [],
    "source": [
     "The MWE was used as followed:\n",
     "\n",
@@ -145,14 +155,14 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2f8b4965-c3e1-420a-82c4-3dfa26b99e86",
+   "cell_type": "markdown",
+   "id": "ef5b413c-5e84-4e30-8340-0aacc13e3491",
    "metadata": {
     "kernel": "SoS"
    },
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Command Interface"
+   ]
   },
   {
    "cell_type": "code",
@@ -176,6 +186,7 @@
       "Workflows:\n",
       "  dbsnp_annotate\n",
       "  qc\n",
+      "  vcf_summary\n",
       "\n",
       "Global Workflow Options:\n",
       "  --genoFile VAL (as path, required)\n",
@@ -226,12 +237,23 @@
       "                        Allele balance for indels\n",
       "      --hwe-filter 1e-06 (as float)\n",
       "                        HWE filter\n",
-      "  qc_3:\n"
+      "  qc_3:\n",
+      "  qc_4, vcf_summary:\n"
      ]
     }
    ],
    "source": [
     "sos run VCF_QC.ipynb -h"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0bbdae32-7fd8-427c-9c45-3cbeaf49bbff",
+   "metadata": {
+    "kernel": "Bash"
+   },
+   "source": [
+    "## Global parameters"
    ]
   },
   {
@@ -282,8 +304,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "several-extra",
+   "execution_count": null,
+   "id": "1f6232a6-41c1-4663-b321-509972250f43",
    "metadata": {
     "kernel": "SoS"
    },
@@ -456,17 +478,15 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SoS",
-   "language": "sos",
-   "name": "sos"
+   "display_name": "Bash",
+   "language": "bash",
+   "name": "bash"
   },
   "language_info": {
-   "codemirror_mode": "sos",
-   "file_extension": ".sos",
-   "mimetype": "text/x-sos",
-   "name": "sos",
-   "nbconvert_exporter": "sos_notebook.converter.SoS_Exporter",
-   "pygments_lexer": "sos"
+   "codemirror_mode": "shell",
+   "file_extension": ".sh",
+   "mimetype": "text/x-sh",
+   "name": "bash"
   },
   "sos": {
    "kernels": [

--- a/code/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/code/data_preprocessing/genotype/VCF_QC.ipynb
@@ -88,7 +88,28 @@
    },
    "source": [
     "## Minimal working example\n",
-    "\n",
+    "The MWE is generated via \n",
+    "```\n",
+    "bcftools query -l get-dosage.ALL.vcf.gz | head -40 > mwe_sample_list\n",
+    "bcftools view -S mwe_sample_list  get-dosage.ALL.vcf.gz > sample_filtered.vcf &\n",
+    "bgzip -c sample_filtered.vcf >  sample_filtered.vcf.gz\n",
+    "tabix -p vcf sample_filtered.vcf.gz\n",
+    "bcftools view --regions chr1 sample_filtered.vcf.gz > chr1_sample_filtered.vcf &\n",
+    "cat chr1_sample_filtered.vcf | head -20000 > mwe_genotype.vcf\n",
+    "```\n",
+    "and was stored here: https://drive.google.com/file/d/1sxxPdPIyKma0mAl8TKwhgyRHlOh0Oyrc/view?usp=sharing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "691cade1-0de8-4c66-a2ef-0c88ccff05af",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "The MWE was used as followed:\n",
     "\n",
     "```\n",
     "sos run VCF_QC.ipynb dbsnp_annotate \\\n",
@@ -101,9 +122,32 @@
     "--genoFile data/mwe/mwe_genotype.vcf     \\\n",
     "--dbsnp-variants data/reference_data/00-All.add_chr.variants.gz  \\\n",
     "--reference-genome data/reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta   \\\n",
-    "--cwd mwe/output/genotype --container ./lmm.sif -J 1 -c csg.yml -q csg  &\n",
-    "```\n"
+    "--cwd mwe/output/genotype_1 --container ./lmm.sif -J 1 -c csg.yml -q csg  &\n",
+    "```\n",
+    "To produce the following results:"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d6a2537c-0053-496d-a764-06708b0f2cf6",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "- Total TSTV for 19639 known variants before QC: 2.599\n",
+    "- Total TSTV for 19573 known variants after QC: 2.600\n",
+    "- There is no novel variants included in the mwe."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2f8b4965-c3e1-420a-82c4-3dfa26b99e86",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",
@@ -217,6 +261,7 @@
    "cell_type": "markdown",
    "id": "removable-extreme",
    "metadata": {
+    "jp-MarkdownHeadingCollapsed": true,
     "kernel": "SoS",
     "tags": []
    },
@@ -245,9 +290,13 @@
     "output: f\"{cwd}/{_input:bnn}.add_chr.vcf.gz\"\n",
     "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
-    "    zcat ${_input} | awk -F\"\\t\" '{if ($0 !~ /^#/) {print \"chr\"$0} else{print $0}}' |\\\n",
-    "        bgzip -c > ${_output}\n",
-    "\n",
+    "    for i in {1..22} X Y MT\n",
+    "    do\n",
+    "        echo \"$i chr$i\" >> chr_name_conv.txt\n",
+    "    done    \n",
+    "    bcftools annotate --rename-chrs chr_name_conv.txt ${_input} -Oz -o ${_output}\n",
+    "    tabix -p vcf ${_output}\n",
+    "    rm chr_name_conv.txt\n",
     "[dbsnp_annotate_2]\n",
     "output: f\"{_input:nn}.variants.gz\"\n",
     "task: trunk_workers = 1, trunk_size=5, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output:bn}'\n",
@@ -290,11 +339,11 @@
     "output: f'{cwd}/{_input:bnn}.{\"leftnorm\" if not bi_allelic else \"biallelic\"}{\".snp\" if snp_only else \"\"}.vcf.gz'\n",
     "task: trunk_workers = 1, trunk_size=job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
-    "        ${'bcftools norm -m-any' if not bi_allelic else 'bcftools view -m2 -M2'} ${'-v snps' if snp_only else \"\"} ${_input} -Oz > ${_output}.tmp_0.vcf.gz\n",
-    "        bcftools norm ${_output}.tmp_0.vcf.gz --check-ref w -f ${reference_genome}  -Oz -o ${_output}.tmp_1.vcf.gz\n",
-    "        bcftools +fill-tags ${_output}.tmp_1.vcf.gz -t all,F_MISSING,'VD=sum(DP)' > ${_output}.tmp_2.vcf\n",
-    "        bcftools annotate ${_output}.tmp_2.vcf -x ID -I +'%CHROM:%POS:%REF:%ALT' > ${_output}.tmp\n",
-    "        bcftools annotate ${_output}.tmp -a ${dbsnp_variants}  -h <(echo '##INFO=<ID=RSID,Number=1,Type=String,Description=\"dbSNP rsID\">') -c CHROM,FROM,TO,ID -Oz -o ${_output}"
+    "        ${'bcftools norm -m-any' if not bi_allelic else 'bcftools view -m2 -M2'} ${'-v snps' if snp_only else \"\"} ${_input} |\\\n",
+    "        bcftools norm --check-ref w -f ${reference_genome}  -Oz|\\\n",
+    "        bcftools +fill-tags -- -t all,F_MISSING,'VD=sum(DP)' | \\\n",
+    "        bcftools annotate -x ID -I +'%CHROM:%POS:%REF:%ALT' | \\\n",
+    "        bcftools annotate -a ${dbsnp_variants}  -h <(echo '##INFO=<ID=RSID,Number=1,Type=String,Description=\"dbSNP rsID\">') -c CHROM,FROM,TO,ID -Oz > ${_output}"
    ]
   },
   {
@@ -388,13 +437,15 @@
     "input: output_from('qc_1'), output_from('qc_2'), group_by = 1\n",
     "output: f\"{cwd}/{_input:bnn}.novel_variant_sumstats\", \n",
     "        f\"{cwd}/{_input:bnn}.known_variant_sumstats\", \n",
-    "        f\"{cwd}/{_input:bnn}.snipsift_tstv\"\n",
+    "        f\"{cwd}/{_input:bnn}.novel_variant.snipsift_tstv\",\n",
+    "        f\"{cwd}/{_input:bnn}.known_variant.snipsift_tstv\"\n",
     "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output[0]:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
     "    # Compute summary statistics, including TS/TV\n",
     "    bcftools stats -i 'ID=\".\"' -v  ${_input} > ${_output[0]}\n",
     "    bcftools stats -i 'ID!=\".\"' -v  ${_input} > ${_output[1]}\n",
-    "    java -jar /opt/snpEff/SnpSift.jar tstv ${_input} > ${_output[2]}"
+    "    bcftools filter -i 'ID=\".\"'  ${_input}   | java -jar /opt/snpEff/SnpSift.jar tstv - > ${_output[2]}\n",
+    "    bcftools filter -i 'ID!=\".\"' ${_input}  | java -jar /opt/snpEff/SnpSift.jar tstv - > ${_output[3]}"
    ]
   }
  ],

--- a/code/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/code/data_preprocessing/genotype/VCF_QC.ipynb
@@ -70,13 +70,18 @@
    "cell_type": "markdown",
    "id": "another-carry",
    "metadata": {
-    "kernel": "SoS"
+    "kernel": "SoS",
+    "tags": []
    },
    "source": [
     "## Input\n",
     "\n",
     "1. The target VCF file to be QC\n",
+    "\n",
+    "    1.1 If the chromosome name of vcf to be qc is not chr*, please run dbsnp_annotate:1 of this module to fix it. Otherwise no need to run it for it is time consuming.\n",
+    "\n",
     "2. dbSNP database in VCF format\n",
+    "\n",
     "3. A reference fasta file"
    ]
   },
@@ -114,7 +119,7 @@
     "```\n",
     "sos run VCF_QC.ipynb dbsnp_annotate \\\n",
     "    --genoFile reference_data/00-All.vcf.gz \\\n",
-    "    --cwd reference_data\n",
+    "    --cwd reference_data --container ./bioinfo.sif\n",
     "```\n",
     "\n",
     "```\n",
@@ -122,7 +127,7 @@
     "--genoFile data/mwe/mwe_genotype.vcf     \\\n",
     "--dbsnp-variants data/reference_data/00-All.add_chr.variants.gz  \\\n",
     "--reference-genome data/reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta   \\\n",
-    "--cwd mwe/output/genotype_1 --container ./lmm.sif -J 1 -c csg.yml -q csg  &\n",
+    "--cwd mwe/output/genotype_1 --container ./bioinfo.sif -J 1 -c csg.yml -q csg  &\n",
     "```\n",
     "To produce the following results:"
    ]

--- a/code/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/code/data_preprocessing/genotype/VCF_QC.ipynb
@@ -162,14 +162,71 @@
     "- There is no novel variants included in the MWE.\n",
     "\n",
     "The Total TS/TV is extracted from the output of qc_4 with following codes:\n",
-    "For known/novel variant before QC:\n",
     "\n",
-    "`grep Ts/Tv {prefix of genoFile}*_variant.snipsift_tstv | rev | cut -d',' -f1 | rev`\n",
-    "\n",
-    "For known/novel variant after QC:\n",
-    "\n",
-    "`grep Ts/Tv {prefix of genoFile}*filtered.*_variant.snipsift_tstv | rev | cut -d',' -f1 | rev`\n",
-    "\n"
+    "For known variant before QC:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "087a98ba-37ba-48f4-9feb-a9675ff43192",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.599\n"
+     ]
+    }
+   ],
+   "source": [
+    "grep Ts/Tv MWE_genotype.leftnorm.known_variant.snipsift_tstv | rev | cut -d',' -f1 | rev"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0dc17c4c-bc96-49bb-bbe2-2b74cd48c8fe",
+   "metadata": {},
+   "source": [
+    "For known variant after QC:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d9e6491b-d362-463d-8ead-b4ea3f903292",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "2.600\n"
+     ]
+    }
+   ],
+   "source": [
+    "grep Ts/Tv MWE_genotype.leftnorm.filtered.*_variant.snipsift_tstv | rev | cut -d',' -f1 | rev"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30e14bfc-e4bf-45e5-b275-0ae536cd5827",
+   "metadata": {},
+   "source": [
+    "For novel variant before/after QC, TS/TV is not avaible since no novel_variants presented in the MWE"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92936230-fece-482c-8b0d-71fc1e23c976",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "grep Ts/Tv MWE_genotype.leftnorm.novel_variant.snipsift_tstv | rev | cut -d',' -f1 | rev\n",
+    "grep Ts/Tv MWE_genotype.leftnorm.filtered.novel_variant.snipsift_tstv | rev | cut -d',' -f1 | rev"
    ]
   },
   {

--- a/code/data_preprocessing/genotype/VCF_QC.ipynb
+++ b/code/data_preprocessing/genotype/VCF_QC.ipynb
@@ -97,11 +97,11 @@
     "```\n",
     "\n",
     "```\n",
-    "sos run VCF_QC.ipynb qc \\\n",
-    "    --genoFile data/mwe_genotype.vcf \\\n",
-    "    --dbsnp-variants reference_data/00-All.renamechrs.add_chr.variants.gz \\\n",
-    "    --reference-genome reference_data/GRCh38_full_analysis_set_plus_decoy_hla.fa\n",
-    "    --cwd output/genotype\n",
+    "sos run VCF_QC.ipynb qc    \\\n",
+    "--genoFile data/mwe/mwe_genotype.vcf     \\\n",
+    "--dbsnp-variants data/reference_data/00-All.add_chr.variants.gz  \\\n",
+    "--reference-genome data/reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta   \\\n",
+    "--cwd mwe/output/genotype --container ./lmm.sif -J 1 -c csg.yml -q csg  &\n",
     "```\n"
    ]
   },
@@ -217,7 +217,8 @@
    "cell_type": "markdown",
    "id": "removable-extreme",
    "metadata": {
-    "kernel": "SoS"
+    "kernel": "SoS",
+    "tags": []
    },
    "source": [
     "## Annotation of known and novel variants\n",
@@ -251,7 +252,7 @@
     "output: f\"{_input:nn}.variants.gz\"\n",
     "task: trunk_workers = 1, trunk_size=5, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
-    "    bcftools query  -f'%CHROM\\t%POS\\t%ID\\t%REF\\t%ALT\\n' ${_input} && | \\\n",
+    "    bcftools query  -f'%CHROM\\t%POS\\t%ID\\t%REF\\t%ALT\\n' ${_input}  | \\\n",
     "        awk 'BEGIN{OFS=\"\\t\";} {if (length ($4) > length ($5)) {print $1,$2,$2+ (length ($4) - 1),$3} else {print $1,$2, $2 + (length ($4) -1 ),$3}}' | \\\n",
     "        bgzip -c > ${_output}"
    ]
@@ -289,11 +290,11 @@
     "output: f'{cwd}/{_input:bnn}.{\"leftnorm\" if not bi_allelic else \"biallelic\"}{\".snp\" if snp_only else \"\"}.vcf.gz'\n",
     "task: trunk_workers = 1, trunk_size=job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
-    "        ${'bcftools norm -m-any' if not bi_allelic else 'bcftools view -m2 -M2'} ${'-v snps' if snp_only else \"\"} ${_input} |\\\n",
-    "        bcftools norm --check-ref w -f ${reference_genome}  -Oz|\\\n",
-    "        bcftools +fill-tags -- -t all,F_MISSING,'VD=sum(DP)' |\\\n",
-    "        bcftools annotate -x ID -I +'%CHROM:%POS:%REF:%ALT' |\\\n",
-    "        bcftools annotate -a ${dbsnp_variants}  -h <(echo '##INFO=<ID=RSID,Number=1,Type=String,Description=\"dbSNP rsID\">') -c CHROM,FROM,TO,RS -Oz > ${_output}"
+    "        ${'bcftools norm -m-any' if not bi_allelic else 'bcftools view -m2 -M2'} ${'-v snps' if snp_only else \"\"} ${_input} -Oz > ${_output}.tmp_0.vcf.gz\n",
+    "        bcftools norm ${_output}.tmp_0.vcf.gz --check-ref w -f ${reference_genome}  -Oz -o ${_output}.tmp_1.vcf.gz\n",
+    "        bcftools +fill-tags ${_output}.tmp_1.vcf.gz -t all,F_MISSING,'VD=sum(DP)' > ${_output}.tmp_2.vcf\n",
+    "        bcftools annotate ${_output}.tmp_2.vcf -x ID -I +'%CHROM:%POS:%REF:%ALT' > ${_output}.tmp\n",
+    "        bcftools annotate ${_output}.tmp -a ${dbsnp_variants}  -h <(echo '##INFO=<ID=RSID,Number=1,Type=String,Description=\"dbSNP rsID\">') -c CHROM,FROM,TO,ID -Oz -o ${_output}"
    ]
   },
   {
@@ -391,8 +392,8 @@
     "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output[0]:bn}'\n",
     "bash: container = container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
     "    # Compute summary statistics, including TS/TV\n",
-    "    bcftools stats -i 'RSID=\".\"' -v  ${_input} > ${_output[0]}\n",
-    "    bcftools stats -i 'RSID!=\".\"' -v  ${_input} > ${_output[1]}\n",
+    "    bcftools stats -i 'ID=\".\"' -v  ${_input} > ${_output[0]}\n",
+    "    bcftools stats -i 'ID!=\".\"' -v  ${_input} > ${_output[1]}\n",
     "    java -jar /opt/snpEff/SnpSift.jar tstv ${_input} > ${_output[2]}"
    ]
   }

--- a/container/docker/bioinfo.dockerfile
+++ b/container/docker/bioinfo.dockerfile
@@ -27,8 +27,8 @@ RUN pip install qtl Biopython
                                      
 RUN cd /tmp && wget http://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_20200616.zip && \
     unzip plink_linux_x86_64_20200616.zip && mv plink /usr/local/bin && rm -rf /tmp/plink*
-RUN cd /tmp && wget https://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_20211217.zip && \
-    unzip plink2_linux_avx2_20211217.zip && mv plink2 /usr/local/bin && rm -rf /tmp/plink2*
+RUN cd /tmp && wget https://s3.amazonaws.com/plink2-assets/alpha2/plink2_linux_avx2.zip && \
+    unzip plink2_linux_avx2.zip && mv plink2 /usr/local/bin && rm -rf /tmp/plink2*
 RUN cd /tmp && wget https://cnsgenomics.com/software/gcta/bin/gcta_1.93.2beta.zip && \
     unzip gcta_1.93.2beta.zip && mv gcta_1.93.2beta/gcta64 /usr/local/bin && rm -rf /tmp/gcta*
 #Install bcftools, tabix, and bgzip

--- a/container/docker/bioinfo.dockerfile
+++ b/container/docker/bioinfo.dockerfile
@@ -1,6 +1,16 @@
 FROM gaow/base-notebook
 LABEL maintainer="Hao Sun<hs3163@cumc.columbia.edu>"
 su -  root # USER root
+
+
+# Install JAVA
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk && \
+  apt-get clean && \
+    apt-get autoremove -y && \
+    rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+
+# Install R pkg
 RUN R --slave -e "install.packages(c('rlang',
                                      'tidyverse',
                                      'BiocManager', 
@@ -40,5 +50,7 @@ RUN cd /tmp && wget https://github.com/samtools/htslib/releases/download/1.12/ht
 RUN cd /tmp && wget https://snpeff.blob.core.windows.net/versions/snpEff_latest_core.zip && \
     unzip snpEff_latest_core.zip &&  \
     mv snpEff /opt && rm -rf /tmp/snpEff*
+    
+
 
 CMD exec /bin/bash "$@"

--- a/container/singularity/bioinfo.def
+++ b/container/singularity/bioinfo.def
@@ -6,6 +6,16 @@ From: gaow/base-notebook
 maintainer="Hao Sun<hs3163@cumc.columbia.edu>"
 %post
 su -  root # USER root
+
+
+# Install JAVA
+apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y default-jdk && \
+apt-get clean && \
+apt-get autoremove -y && \
+rm -rf /var/lib/{apt,dpkg,cache,log}/
+
+
+# Install R pkg
 R --slave -e "install.packages(c('rlang',
                                      'tidyverse',
                                      'BiocManager', 
@@ -45,6 +55,8 @@ cp tabix bgzip htsfile /usr/local/bin && rm -rf /tmp/htslib*
 cd /tmp && wget https://snpeff.blob.core.windows.net/versions/snpEff_latest_core.zip && \
 unzip snpEff_latest_core.zip &&  \
 mv snpEff /opt && rm -rf /tmp/snpEff*
+    
+
 
 %runscript
 exec /bin/bash exec /bin/bash "$@"

--- a/container/singularity/bioinfo.def
+++ b/container/singularity/bioinfo.def
@@ -32,8 +32,8 @@ pip install qtl Biopython
                                      
 cd /tmp && wget http://s3.amazonaws.com/plink1-assets/plink_linux_x86_64_20200616.zip && \
 unzip plink_linux_x86_64_20200616.zip && mv plink /usr/local/bin && rm -rf /tmp/plink*
-cd /tmp && wget https://s3.amazonaws.com/plink2-assets/plink2_linux_avx2_20211217.zip && \
-unzip plink2_linux_avx2_20211217.zip && mv plink2 /usr/local/bin && rm -rf /tmp/plink2*
+cd /tmp && wget https://s3.amazonaws.com/plink2-assets/alpha2/plink2_linux_avx2.zip && \
+unzip plink2_linux_avx2.zip && mv plink2 /usr/local/bin && rm -rf /tmp/plink2*
 cd /tmp && wget https://cnsgenomics.com/software/gcta/bin/gcta_1.93.2beta.zip && \
 unzip gcta_1.93.2beta.zip && mv gcta_1.93.2beta/gcta64 /usr/local/bin && rm -rf /tmp/gcta*
 #Install bcftools, tabix, and bgzip


### PR DESCRIPTION
1. The VCF_QC pipeline can work with the MWE and produce the qc plot
1.1 Originally RS & RSID was used as tags for snp names. As it turn out only ID works otherwise error will be raised, so I changes both into ID.
1.2 Potential reason why Diana's work is that maybe her input vcf have a RS field already, but ours don't.

However, please dont merge the pr for the moment as the qc module is broke down to produce intermediate products for each command to solve the following issues:

2. The vcf_qc pipeline still produce empty result for the complete data:
2.1 one potential cause of 2 is at the moment the improper way to rename the vcf file: the header is not changes.
2.2 another potential cause of 2 is the lack of indexing of the vcf input.

after fixing 2.1 and 2.2, the tmp_0 and tmp_1 intermediate product is complete, but tmp_2 is still empty.
Will keep debugging, and properly implement 2.1 and 2.2 as a dedicated step, perhaps in place of dbsnp_1,  into the module when VCF_QC can work on full data.

