### PR TITLE
add --output-chr on genotype_reformatting

### DIFF
--- a/code/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/association_scan/TensorQTL/TensorQTL.ipynb
@@ -166,7 +166,7 @@
     "import pandas as pd\n",
     "molecular_pheno_chr_inv = pd.read_csv(molecular_pheno_list,sep = \"\\t\")\n",
     "geno_chr_inv = pd.read_csv(genotype_file_list,sep = \"\\t\")\n",
-    "input_inv = molecular_pheno_chr_inv.merge(geno_chr_inv, on = \"#chr\")\n",
+    "input_inv = molecular_pheno_chr_inv.merge(geno_chr_inv, on = \"#id\")\n",
     "input_inv = input_inv.values.tolist()"
    ]
   },

--- a/code/data_preprocessing/genotype/GWAS_QC.ipynb
+++ b/code/data_preprocessing/genotype/GWAS_QC.ipynb
@@ -612,7 +612,7 @@
     "      --make-bed \\\n",
     "      --out ${_output[0]:n} \\\n",
     "      --threads ${numThreads} \\\n",
-    "      --memory ${int(expand_size(mem) * 0.9)/1e6} \n",
+    "      --memory ${int(expand_size(mem) * 0.9)/1e6} --new-id-max-allele-len 1000 --set-all-var-ids chr@:#_\\$r_\\$a \n",
     "\n",
     "    plink \\\n",
     "      --bfile ${_input[1]:n} \\\n",
@@ -620,7 +620,7 @@
     "      --make-bed \\\n",
     "      --out ${_output[1]:n} \\\n",
     "      --threads ${numThreads} \\\n",
-    "      --memory ${int(expand_size(mem) * 0.9)/1e6} "
+    "      --memory ${int(expand_size(mem) * 0.9)/1e6} --new-id-max-allele-len 1000 --set-all-var-ids chr@:#_\\$r_\\$a "
    ]
   },
   {
@@ -683,7 +683,7 @@
     "      --make-bed \\\n",
     "      --out ${_output:n} \\\n",
     "      --threads ${numThreads} \\\n",
-    "      --memory ${int(expand_size(mem) * 0.9)/1e6}"
+    "      --memory ${int(expand_size(mem) * 0.9)/1e6} --new-id-max-allele-len 1000 --set-all-var-ids chr@:#_\\$r_\\$a "
    ]
   },
   {

--- a/code/data_preprocessing/genotype/genotype_formatting.ipynb
+++ b/code/data_preprocessing/genotype/genotype_formatting.ipynb
@@ -295,8 +295,8 @@
     "    plink --bfile ${_input:n} \\\n",
     "        --recode vcf-iid  \\\n",
     "        --out ${_output[0]:nn} \\\n",
-    "        --threads ${numThreads} \\\n",
-    "        --memory ${int(expand_size(mem) * 0.9)/1e06}\n",
+    "        --threads ${numThreads} \\ \n",
+    "        --memory ${int(expand_size(mem) * 0.9)/1e06} --output-chr chrMT\n",
     "\n",
     "    bgzip -l 9 ${_output[0]:n}  \n",
     "    tabix -f -p vcf ${_output[0]}"
@@ -373,7 +373,7 @@
     "        --chr ${_regions[0]} \\\n",
     "        --from-bp ${f'1' if (int(_regions[1]) - window) < 0 else f'{(int(_regions[1]) - window)}'} \\\n",
     "        --to-bp ${int(_regions[2]) + window} \\\n",
-    "        --allow-no-sex || touch ${_output}"
+    "        --allow-no-sex --output-chr chrMT || touch ${_output}"
    ]
   },
   {
@@ -408,7 +408,7 @@
     "    --make-bed \\\n",
     "    --out $[_output[0]:n] \\\n",
     "    --chr $[_chrom] \\\n",
-    "    --allow-no-sex || true"
+    "    --allow-no-sex --output-chr chrMT  || true "
    ]
   },
   {

--- a/code/data_preprocessing/phenotype/phenotype_formatting.ipynb
+++ b/code/data_preprocessing/phenotype/phenotype_formatting.ipynb
@@ -115,11 +115,11 @@
     "[reformat_1,partition_by_chrom_1]\n",
     "# Path to the input molecular phenotype data.\n",
     "input: phenoFile ,for_each = \"chrom\"\n",
-    "output: f'{cwd:a}/{name}.chr{_chrom}.mol_phe.bed.gz'\n",
+    "output: f'{cwd:a}/{name}.{_chrom}.mol_phe.bed.gz'\n",
     "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime,  mem = mem, tags = f'{step_name}_{_output:bn}'  \n",
     "bash: expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout',container = container\n",
     "    zcat $[_input] | head -1 > $[_output:n]\n",
-    "    tabix $[_input] $[_chrom] >> $[_output:n]\n",
+    "    tabix $[_input] $[_chrom] >> $[_output:n] \n",
     "    bgzip -f $[_output:n]\n",
     "    tabix -p bed $[_output] -f"
    ]
@@ -138,7 +138,7 @@
     "input: group_by = \"all\"\n",
     "output: f'{cwd:a}/{name}.processed_phenotype.per_chrom.recipe'\n",
     "import pandas as pd\n",
-    "chrom_df = pd.DataFrame({\"#chr\" : chrom ,\"#dir\" : _input})\n",
+    "chrom_df = pd.DataFrame({\"#id\" : chrom ,\"#dir\" : _input})\n",
     "chrom_df.to_csv(_output,index = 0,sep = \"\\t\")"
    ]
   },
@@ -186,7 +186,7 @@
     "input: group_by = \"all\"\n",
     "output: f'{cwd:a}/{name}.processed_phenotype.per_gene.recipe'\n",
     "import pandas as pd\n",
-    "region_df = pd.DataFrame({\"region\" : [x[3] for x in regions] ,\"dir\" : _input})\n",
+    "region_df = pd.DataFrame({\"#id\" : [x[3] for x in regions] ,\"dir\" : _input})\n",
     "region_df.to_csv(_output,index = 0,sep = \"\\t\")"
    ]
   }


### PR DESCRIPTION
Implemented changes described in #178 

Working on reorganizing the flowchart and then automate the data_processing step before and after check point.

Also, adding back the previously removed mechanism to ensure the correctness of snp name format within the GWAS_QC module.