### PR TITLE
PCA + mastercontrol for data_proc reworked

### DIFF
--- a/code/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/association_scan/TensorQTL/TensorQTL.ipynb
@@ -363,7 +363,7 @@
     "    import csv\n",
     "    import pandas as pd \n",
     "    data_tempt = pd.DataFrame({\n",
-    "    \"#chr\" : [int(x[0].split(\".\")[-4].replace(\"chr\",\"\")) for x in  [$[_input:r,]]],\n",
+    "    \"#chr\" : [int(x.split(\".\")[-4].replace(\"chr\",\"\")) for x in  [$[_input:r,]]],\n",
     "    \"sumstat_dir\" : [$[_input:r,]]\n",
     "    })\n",
     "    data_tempt.to_csv(\"$[_output]\",index = False,sep = \"\\t\" )"

--- a/code/complete_analysis/eQTL_analysis.ipynb
+++ b/code/complete_analysis/eQTL_analysis.ipynb
@@ -8,9 +8,9 @@
     "tags": []
    },
    "source": [
-    "# Bulk RNA-seq eQTL analysis\n",
+    "# Bulk RNA-seq eQTL analysis-external bed input.\n",
     "\n",
-    "This notebook provide a master control on the XQTL workflow so it can works on multiple data collection as proposed.\n",
+    "This notebook provide a master control on the XQTL workflow so it can automate variouse s on multiple data collection as proposed.\n",
     "Input:\n",
     "    A recipe file,each row is a data collection and with the following column:\n",
     "    \n",

--- a/code/complete_analysis/eQTL_analysis_externalBed.ipynb
+++ b/code/complete_analysis/eQTL_analysis_externalBed.ipynb
@@ -1,0 +1,697 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "above-tonight",
+   "metadata": {
+    "kernel": "SoS",
+    "tags": []
+   },
+   "source": [
+    "# Bulk RNA-seq eQTL analysis, external_bed\n",
+    "\n",
+    "This notebook provide a master control on the XQTL workflow so it can automate the work before data preprocessing on multiple data collection as proposed.\n",
+    "\n",
+    "This master control notebook is mainly to serve the 8 tissues snuc_bulk_expression analysis, but should be functional on all analysis where expression data an\n",
+    "\n",
+    "Input:\n",
+    "    A recipe file,each row is a data collection and with the following column:\n",
+    "    \n",
+    "    Theme\n",
+    "        name of dataset, must be different, each uni_study analysis will be performed in a folder named after each, meta analysis will be performed in a folder named as {study1}_{study2}\n",
+    "            \n",
+    "        The column name must contain the # and be the first column\n",
+    "    \n",
+    "    genotype_file\n",
+    "        {Path to a whole genome genotype file}\n",
+    "    \n",
+    "    molecular_pheno\n",
+    "        {Path to file}\n",
+    "        \n",
+    "    sample_name_indexer\n",
+    "        {path}\n",
+    "    gtf reference data\n",
+    "        {path}\n",
+    "    \n",
+    "    \n",
+    "    ### note: Only data collection from the same Populations and conditions will me merged to perform Fix effect meta analysis\n",
+    "    \n",
+    "Output:\n",
+    "    ..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "mobile-stanley",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Generation of MWE\n",
+    "This is the code to generate the mwe recipe and LD_recipe on csg cluster\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "republican-leone",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "Recipe_temp = pd.DataFrame( {\"Theme\" : [\"AC\",\"DLPFC\",\"PCC\"] ,\n",
+    "                \"genotype_list\" : [\"/home/hs3163/GIT/ADSPFG-xQTL/MWE/mwe_genotype_list\",\n",
+    "                   \"/home/hs3163/GIT/ADSPFG-xQTL/MWE/mwe_genotype_list\",\n",
+    "                   \"/home/hs3163/GIT/ADSPFG-xQTL/MWE/mwe_genotype_list\"],\n",
+    "                \"molecular_pheno\" : [\"/home/hs3163/Project/Rosmap/data/gene_exp/AC/geneTpmResidualsAgeGenderAdj_rename.txt\",\n",
+    "                     \"/home/hs3163/Project/Rosmap/data/gene_exp/DLPFC/geneTpmResidualsAgeGenderAdj_rename.txt\",\n",
+    "                     \"/home/hs3163/Project/Rosmap/data/gene_exp/PCC/geneTpmResidualsAgeGenderAdj_rename.txt\"],\n",
+    "                \"region_list\" : [\"~/GIT/ADSPFG-xQTL/MWE/mwe_region\",\n",
+    "                \"~/GIT/ADSPFG-xQTL/MWE/mwe_region\",\n",
+    "                \"~/GIT/ADSPFG-xQTL/MWE/mwe_region\"] ,\n",
+    "                \"covariate_file\" : [\"/home/hs3163/GIT/ADSPFG-xQTL/MWE/MWE.cov\",\"/home/hs3163/GIT/ADSPFG-xQTL/MWE/MWE.cov\",\"/home/hs3163/GIT/ADSPFG-xQTL/MWE/MWE.cov\"],\n",
+    "                \"factor_analysis_opt\" : [\"APEX\",\"APEX\",\"APEX\"],\n",
+    "                \"LD_Recipe\": [\"~/GIT/ADSPFG-xQTL/MWE/LD_Recipe\",\"~/GIT/ADSPFG-xQTL/MWE/LD_Recipe\",\"~/GIT/ADSPFG-xQTL/MWE/LD_Recipe\"],\n",
+    "                \"QTL_tool_option\" : [\"APEX\",\"APEX\",\"APEX\"],\n",
+    "                \"QTL_analysis_option\" : [\"cis\",\"cis\",\"cis\"],\n",
+    "                \"cis_windows\" : [500000,500000,5000000],\n",
+    "                \"Metal\" : [\"T\",\"T\",\"F\"]}).to_csv(\"/home/hs3163/GIT/ADSPFG-xQTL/MWE/mwe_recipe_example\",\"\\t\")\n",
+    "\n",
+    "        ### note: Only data collection from the same Populations and conditions will me merged to perform Fix effect meta analysis\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "hindu-casting",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "pd.DataFrame( {\"Theme\" : [\"AC\",\"DLPFC\",\"PCC\"] ,\n",
+    "                \"genotype_list\" : [\" /mnt/mfs/statgen/ROSMAP_xqtl/Rosmap_wgs_genotype_list.txt\",\n",
+    "                   \" /mnt/mfs/statgen/ROSMAP_xqtl/Rosmap_wgs_genotype_list.txt\",\n",
+    "                   \" /mnt/mfs/statgen/ROSMAP_xqtl/Rosmap_wgs_genotype_list.txt\"],\n",
+    "                \"molecular_pheno\" : [\"/home/hs3163/Project/Rosmap/data/gene_exp/AC/geneTpmResidualsAgeGenderAdj_rename.txt\",\n",
+    "                     \"/home/hs3163/Project/Rosmap/data/gene_exp/DLPFC/geneTpmResidualsAgeGenderAdj_rename.txt\",\n",
+    "                     \"/home/hs3163/Project/Rosmap/data/gene_exp/PCC/geneTpmResidualsAgeGenderAdj_rename.txt\"],\n",
+    "                \"region_list\" : [\"/home/hs3163/Project/Rosmap/data/gene_exp/AC/geneTpmResidualsAgeGenderAdj_rename_region_list.txt\",\n",
+    "                \"/home/hs3163/Project/Rosmap/data/gene_exp/AC/geneTpmResidualsAgeGenderAdj_rename_region_list.txt\",\n",
+    "                \"/home/hs3163/Project/Rosmap/data/gene_exp/AC/geneTpmResidualsAgeGenderAdj_rename_region_list.txt\"] ,\n",
+    "                \"covariate_file\" : [\"None\",\"None\",\"None\"],\n",
+    "                \"factor_analysis_opt\" : [\"BiCV\",\"BiCV\",\"BiCV\"],\n",
+    "                \"LD_Recipe\": [\"~/GIT/ADSPFG-xQTL/MWE/LD_Recipe\",\"~/GIT/ADSPFG-xQTL/MWE/LD_Recipe\",\"~/GIT/ADSPFG-xQTL/MWE/LD_Recipe\"],\n",
+    "                \"QTL_tool_option\" : [\"APEX\",\"APEX\",\"APEX\"],\n",
+    "                \"QTL_analysis_option\" : [\"cis\",\"cis\",\"cis\"],\n",
+    "                \"cis_windows\" : [500000,500000,500000],\n",
+    "                \"Metal\" : [\"T\",\"T\",\"F\"]}).to_csv(\"/home/hs3163/GIT/xqtl-pipeline/ROSMAP_recipe_example\",\"\\t\", index = 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "liquid-acoustic",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "home/hs3163/GIT/xqtl-pipeline/ROSMAP_recipe_example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "demanding-pantyhose",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "pd.DataFrame({\"ld_file_prefix\" : [\"/mnt/mfs/statgen/neuro-twas/mv_wg/cache_arch/cache/geneTpmResidualsAgeGenderAdj_rename.\",\"/mnt/mfs/statgen/neuro-twas/mv_wg/cache_arch/cache/geneTpmResidualsAgeGenderAdj_rename.\"],\n",
+    "               \"ld_file_surfix\" : [\".merged.ld.rds\",\".merged.ld.rds\"]}).to_csv(\"~/GIT/ADSPFG-xQTL/MWE/LD_Recipe\",sep = \"\\t\")\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "identified-reward",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "nohup sos run /home/hs3163/GIT/xqtl-pipeline/pipeline/complete_analysis/eQTL_analysis.ipynb QTL \\\n",
+    "    --recipe /home/hs3163/GIT/ADSPFG-xQTL/MWE/mwe_recipe_example \\\n",
+    "    --wd ./ \\\n",
+    "    --exe_dir \"/home/hs3163/GIT/xqtl-pipeline/pipeline/\" &"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "portable-conservative",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "nohup sos dryrun /home/hs3163/GIT/xqtl-pipeline/pipeline/complete_analysis/eQTL_analysis.ipynb mash_to_vcf \\\n",
+    "--recipe /home/hs3163/GIT/xqtl-pipeline/ROSMAP_recipe_example --wd ./ --exe_dir \"~/GIT/xqtl-pipeline/pipeline/\" -s build &\n",
+    "\n",
+    "nohup sos dryrun /home/hs3163/GIT/xqtl-pipeline/pipeline/complete_analysis/eQTL_analysis.ipynb phenotype_reformatting_by_gene \\\n",
+    "--recipe /home/hs3163/GIT/xqtl-pipeline/ROSMAP_recipe_example --wd ./ --exe_dir \"~/GIT/xqtl-pipeline/pipeline/\" -s build &\n",
+    "\n",
+    "nohup sos dryrun /home/hs3163/GIT/xqtl-pipeline/pipeline/complete_analysis/eQTL_analysis.ipynb genotype_reformatting_per_gene \\\n",
+    "--recipe /home/hs3163/GIT/xqtl-pipeline/ROSMAP_recipe_example --wd ./ --exe_dir \"~/GIT/xqtl-pipeline/pipeline/\" -s build &\n",
+    "\n",
+    "nohup sos dryrun /home/hs3163/GIT/xqtl-pipeline/pipeline/complete_analysis/eQTL_analysis.ipynb mixture_prior \\\n",
+    "--recipe /home/hs3163/GIT/xqtl-pipeline/ROSMAP_recipe_example --wd ./ --exe_dir \"~/GIT/xqtl-pipeline/pipeline/\" -s build &\n",
+    "\n",
+    "\n",
+    "nohup sos run ~/GIT/bioworkflows/GWAS/PCA.ipynb flashpca \\\n",
+    "   --genoFile /mnt/mfs/statgen/xqtl_workflow_testing/ROSMAP/data_preprocessing/genotype/qc/PCC.mergrd.filtered.prune.unrelated.bed \\\n",
+    "   --name PCC \\\n",
+    "   --container_lmm /mnt/mfs/statgen/containers/xqtl_pipeline_sif/flashpcaR.sif \\\n",
+    "   --cwd /mnt/mfs/statgen/xqtl_workflow_testing/demo/test_pca/ \\\n",
+    "   -J 200 -q csg -c /home/hs3163/GIT/ADSPFG-xQTL/code/csg.yml &\n",
+    "\n",
+    "nohup sos run ~/GIT/bioworkflows/GWAS/PCA.ipynb project_samples:1 \\\n",
+    "   --genoFile /mnt/mfs/statgen/xqtl_workflow_testing/ROSMAP/data_preprocessing/genotype/qc/PCC.mergrd.filtered.prune.related.bed \\\n",
+    "   --pca_model  /mnt/mfs/statgen/xqtl_workflow_testing/demo/test_pca/PCC.mergrd.filtered.prune.unrelated.PCC.pca.rds \\\n",
+    "   --name PCC \\\n",
+    "   --container_lmm /mnt/mfs/statgen/containers/xqtl_pipeline_sif/flashpcaR.sif \\\n",
+    "   --cwd /mnt/mfs/statgen/xqtl_workflow_testing/demo/test_pca/ \\\n",
+    "   -J 200 -q csg -c /home/hs3163/GIT/ADSPFG-xQTL/code/csg.yml &"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intended-parliament",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Example for running the workflow\n",
+    "This will run the workflow from via several submission and save the output to nohup.out"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "challenging-sucking",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abandoned-initial",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dominant-spyware",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Other example workflow:\n",
+    "These command run each of the substep to test them individually"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "scientific-merit",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "moderate-samuel",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[global]\n",
+    "## The aforementioned input recipe\n",
+    "parameter: recipe = path\n",
+    "## Overall wd, the file structure of analysis is wd/[steps]/[sub_dir for each steps]\n",
+    "parameter:  cwd = path(\".\")\n",
+    "## Diretory to the excutable\n",
+    "parameter: exe_dir = path(\"~/GIT/xqtl-pipeline/\")\n",
+    "parameter: container = '/mnt/mfs/statgen/containers/twas_latest.sif'\n",
+    "parameter: container_base_bioinfo = '/mnt/mfs/statgen/containers/bioinfo.sif'\n",
+    "parameter: container_apex = '/mnt/mfs/statgen/containers/apex.sif'\n",
+    "parameter: container_PEER = '/mnt/mfs/statgen/containers/PEER.sif'\n",
+    "parameter: container_TensorQTL = '/mnt/mfs/statgen/containers//TensorQTL.sif'\n",
+    "parameter: container_rnaquant = '/mnt/mfs/statgen/containers/rna_quantification.sif'\n",
+    "parameter: container_flashpca = '/mnt/mfs/statgen/containers/flashpca.sif'\n",
+    "parameter: annotation_gtf = path\n",
+    "parameter: sample_participant_lookup = path\n",
+    "parameter: phenotype_id_type = \"gene_name\" \n",
+    "parameter: yml = path(\"csg.yml\")\n",
+    "import os"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "objective-wrestling",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Molecular Phenotype Calling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "metallic-circulation",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fifth-holder",
+   "metadata": {
+    "kernel": "SoS",
+    "tags": []
+   },
+   "source": [
+    "## Data Preprocessing\n",
+    "### Molecular Phenotype Processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "advisory-relationship",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "#[Normalization]\n",
+    "#import os\n",
+    "#input: for_each = \"input_inv\"\n",
+    "#skip_if( os.path.exists(_input_inv[\"molecular_pheno\"]))\n",
+    "#output: f'{cwd:a}/data_preprocessing/normalization/{name}.mol_phe.bed.gz'\n",
+    "#bash:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "#    sos run $[exe_dir]/data_preprocessing/phenotype/GWAS_QC.ipynb output \\\n",
+    "#        --counts_gct $[_input_inv[\"genecount_table\"]] \\\n",
+    "#        --tpm_gct $[_input_inv[\"geneTpm_table\"]] \\\n",
+    "#        --sample_participant_lookup $[_input_inv[\"sample_index\"]] \\\n",
+    "#        --vcf_chr_list $[_input_inv[\"vcf_chr_list\"]] \\\n",
+    "#        --container $[container_gtex] \\\n",
+    "#        --name $[_input_inv[\"Theme\"]] \\\n",
+    "#        --wd $[wd:a]/data_preprocessing/normalization/ \\\n",
+    "#        --container $[container_base_bioinfo] \\\n",
+    "#        -J 200 -q csg -c $[yml] &"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "indie-japanese",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[annotation]\n",
+    "## Must be ran with internet connection\n",
+    "import os\n",
+    "input: for_each = \"input_inv\"\n",
+    "output: f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/phenotype_data/{_input_inv[\"Theme\"]}.{path(_input_inv[\"molecular_pheno\"]):bn}.bed.gz'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "  sos run $[exe_dir]/pipeline/gene_annotation.ipynb annotate_coord \\\n",
+    "    --cwd $[_output:d] \\\n",
+    "    --phenoFile $[_input_inv[\"molecular_pheno\"]] \\\n",
+    "    --annotation-gtf $[annotation_gtf] \\\n",
+    "    --sample-participant-lookup $[sample_participant_lookup] \\\n",
+    "    --container $[container_rnaquant] \\\n",
+    "    --phenotype-id-type $[phenotype_id_type] -J 1 -c csg.yml -q csg "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "chief-blame",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[region_list_generation]\n",
+    "input: output_from(\"annotation\"), group_with = \"input_inv\"\n",
+    "output: pheno_mod = f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/phenotype_data/{_input_inv[\"Theme\"]}.region_list'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "    sos run $[exe_dir]/pipeline/gene_annotation.ipynb region_list_generation \\\n",
+    "        --cwd $[_output:d]  \\\n",
+    "        --phenoFile $[_input:d]\\\n",
+    "        --annotation-gtf $[annotation_gtf] \\\n",
+    "        --sample-participant-lookup $[sample_participant_lookup] \\\n",
+    "        --container $[container_rnaquant] \\\n",
+    "        --phenotype-id-type $[phenotype_id_type] -J 1 -c csg.yml -q csg "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c71dcb67-f366-41a1-b0ca-09bd4d293601",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[phenotype_partition_by_chrom]\n",
+    "input: output_from(\"annotation\"),output_from(\"region_list_generation\"), group_with = \"input_inv\"\n",
+    "output: per_chrom_pheno_list = f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/phenotype_data/{_input_inv[\"Theme\"]}.per_chrom_pheno_list'        \n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "sos run $[exe_dir]/pipeline/phenotype_formatting.ipynb partition_by_chrom \\\n",
+    "    --cwd $[_output:d]  \\\n",
+    "    --phenoFile $[_input[0]:d] \\\n",
+    "    --region-list $[_input[1]:d] \\\n",
+    "    --container $[container_rnaquant] \\\n",
+    "    -J 30 -c csg.yml -q csg --mem 4G "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "portuguese-marking",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "### Genotype Processing\n",
+    "Since genotype is shared among the eight tissue, the QC of whole genome file is not needed. Only pca needed to be run again."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79acb9fc-b803-4939-80c9-32cec7308170",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[sample_match]\n",
+    "input:for_each = \"input_inv\"\n",
+    "output: f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/{sample_participant_lookup:n}.filtered.txt',\n",
+    "        geno = f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/{sample_participant_lookup:n}.filtered_geno.txt'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "    sos run $[exe_dir]/pipeline/sample_matcher.ipynb filtered_sample_list \\\n",
+    "        --cwd $[_output[0]:d]  \\\n",
+    "        --phenoFile $[_input_inv[\"molecular_pheno\"]]  \\\n",
+    "        --genoFile $[_input_inv[\"genotype_file\"]]  \\\n",
+    "        --sample-participant-lookup $[sample_participant_lookup] \\\n",
+    "        --container $[container_rnaquant] \\\n",
+    "        --translated_phenoFile -J 1 -c csg.yml -q csg "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64df9826-b0b5-4c67-b52f-6f4e96a318cb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[king]\n",
+    "input:output_from(\"sample_match\"), group_with = \"input_inv\"\n",
+    "output: related = f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/genotype_data/{path(_input_inv[\"genotype_file\"]):bn}.related.bed',\n",
+    "        unrelated = f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/genotype_data/{path(_input_inv[\"genotype_file\"]):bn}.unrelated.bed'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    " sos run $[exe_dir]/pipeline/GWAS_QC.ipynb king \\\n",
+    "    --cwd $[_output[0]:d] \\\n",
+    "    --genoFile $[_input_inv[\"genotype_file\"]] \\\n",
+    "    --name $[_input_inv[\"Theme\"]] \\\n",
+    "    --keep-samples $[_input] \\\n",
+    "    --container $[container_base_bioinfo]  -J 1 -c csg.yml -q csg --walltimes 48h -s force "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bb56d62f-a560-4802-9fd8-ded3ada60a93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[unrelated_QC]\n",
+    "input: output_from(\"king\")[\"unrelated\"]\n",
+    "output: unrelated_bed = f'{_input:n}.filtered.prune.bed', \n",
+    "        prune = f'{_input:n}.filtered.prune.in'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    " sos run $[exe_dir]/pipeline/GWAS_QC.ipynb qc \\\n",
+    "    --cwd $[_output[0]:d] \\\n",
+    "    --genoFile$[_input] \\\n",
+    "    --exclude-variants /mnt/mfs/statgen/snuc_pseudo_bulk/Ast/genotype/dupe_snp_to_exclude \\\n",
+    "    --maf-filter 0.05 \\\n",
+    "    --container $[container_base_bioinfo] -J 1 -c csg.yml -q csg --mem 40G  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6109d434-a4f0-4543-b912-1f2e64b0c54a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[related_QC]\n",
+    "input: output_from(\"king\")[\"related\"],output_from(\"unrelated_QC\")[\"prune\"]\n",
+    "output: f'{_input:n}.filtered.prune.bed'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    " sos run $[exe_dir]/pipeline/GWAS_QC.ipynb qc \\\n",
+    "    --cwd $[_output[0]:d] \\\n",
+    "    --genoFile $[_input[0]] \\\n",
+    "    --exclude-variants /mnt/mfs/statgen/snuc_pseudo_bulk/Ast/genotype/dupe_snp_to_exclude \\\n",
+    "    --maf-filter 0 --geno-filter 0 --mind-filter 0.1 --hwe-filter 0 \\\n",
+    "    --keep-variants $[_input[1]]  \\\n",
+    "    --container $[container_base_bioinfo] -J 1 -c csg.yml -q csg --mem 40G  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "impressive-organ",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[genotype_reformatting_per_gene]\n",
+    "import pandas as pd\n",
+    "input: output_from(\"genotype_QC\")[\"merged_plink\"], group_with = \"input_inv\"\n",
+    "name = _input_inv[\"Theme\"]\n",
+    "output: per_gene_plink = f'{cwd}/data_preprocessing/genotype/{name}_per_gene_plink/{name}.plink_gene_list.txt'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "        sos run $[exe_dir]/data_preprocessing/genotype/genotype_formatting.ipynb plink_by_gene \\\n",
+    "                --genoFile $[_input] \\\n",
+    "                --name $[_input_inv[\"Theme\"]] \\\n",
+    "                --region_list $[_input_inv[\"region_list\"]] \\\n",
+    "                --container $[container_base_bioinfo] \\\n",
+    "                --region_list $[_input_inv[\"region_list\"]] \\\n",
+    "                --wd $[wd:a]/data_preprocessing/genotype/ \\\n",
+    "                -J 2000 -q csg -c $[yml] "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "functional-cheat",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[LD]\n",
+    "import pandas as pd\n",
+    "input: output_from(\"genotype_reformatting\")[\"per_gene_plink\"],group_with = \"input_inv\"\n",
+    "output: f'{cwd}/data_preprocessing/genotype/LD/{_input_inv[\"Theme\"]}._LD_recipe'\n",
+    "#task: trunk_workers = 1, trunk_size = 1, walltime = '24h',  mem = '40G', tags = f'{step_name}_{_output[0]:bn}'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "     sos run $[exe_dir]/data_preprocessing/genotype/LD.ipynb LD \\\n",
+    "        --genotype_list $[_input] \\\n",
+    "        --name $[_input_inv[\"Theme\"]] \\\n",
+    "        --container $[container_base_bioinfo] \\\n",
+    "        --wd $[wd:a]/data_preprocessing/genotype/LD/ \\\n",
+    "        -J 200 -q csg -c $[yml] "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "asian-henry",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[LD_Recipe]\n",
+    "input: output_from(\"LD\"), group_by = \"all\"\n",
+    "output: f'{cwd:a}/data_preprocessing/genotype/LD/sumstat_list'\n",
+    "python: expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "    import pandas as pd\n",
+    "    input_list = [$[_input:r,]]\n",
+    "    ld_recipe = pd.read_csv(input_list[0],sep = \"\\t\")\n",
+    "    for x in range(1,len(input_list)):\n",
+    "        ld_recipe = ld_recipe.append(pd.read_csv(input_list[x],sep = \"\\t\"))\n",
+    "    ld_recipe.to_csv(\"$[_output]\", index = 0 , sep = \"\\t\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "offshore-eleven",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[GRM]\n",
+    "import pandas as pd\n",
+    "input: output_from(\"genotype_reformatting\")[\"per_chrom_plink_list\"],group_with = \"input_inv\"\n",
+    "output: f'{cwd}/data_preprocessing/genotype/grm/{_input_inv[\"Theme\"]}.grm_list.txt'\n",
+    "#task: trunk_workers = 1, trunk_size = 1, walltime = '24h',  mem = '40G', tags = f'{step_name}_{_output[0]:bn}'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "     sos run $[exe_dir]/data_preprocessing/genotype/GRM.ipynb GRM \\\n",
+    "        --genotype_list $[_input] \\\n",
+    "        --name $[_input_inv[\"Theme\"]] \\\n",
+    "        --container $[container_base_bioinfo] \\\n",
+    "        --wd $[wd:a]/data_preprocessing/genotype/grm/ \\\n",
+    "        -J 200 -q csg -c $[yml] "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "noted-opening",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Factor analysis"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "01fb7095-247e-44eb-aaa3-0f050c358b73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[pca]\n",
+    "input: output_from(\"unrelated_QC\")[\"unrelated_bed\"],group_with = \"input_inv\"\n",
+    "output: f'{cwd}/data_preprocessing/{_input_inv[\"Theme\"]}/pca/{_input:bn}.pca.rds',\n",
+    "        f'{cwd}/data_preprocessing/{_input_inv[\"Theme\"]}/pca/{_input:bn}.pca.scree.txt'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "     sos run $[exe_dir]/pipeline/PCA.ipynb flashpca \\\n",
+    "        --cwd $[_output:d] \\\n",
+    "        --genoFile $[_input] \\\n",
+    "        --container $[container_flashpca] -J 1 -c csg.yml -q csg  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bd276535-2566-4b17-b27d-27688e8c6ef7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[projected_sample]\n",
+    "# The percentage \n",
+    "parameter: PVE_treshold = 0.7\n",
+    "input: output_from(\"related_QC\"),output_from(\"pca\"), group_with = \"input_inv\"\n",
+    "output: f'{cwd}/data_preprocessing/{_input_inv[\"Theme\"]}/pca/{_input:bn}.pca.projected.rds'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "    sos run $[exe_dir]/pipeline/PCA.ipynb project_samples \\\n",
+    "            --cwd $[_output:d] \\\n",
+    "            --genoFile $[_input[0]] \\\n",
+    "            --pca-model  $[_input[1]] \\\n",
+    "            --maha-k `awk '$3 < $[PVE_treshold]' $[_input[2]] | tail -1 | cut -f 1  ` \\\n",
+    "            --k `awk '$3 < $[PVE_treshold]' $[_input[2]] | tail -1 | cut -f 1 ` \\\n",
+    "            --container $[container_flashpca] -J 1 -c csg.yml -q csg "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "stretch-indianapolis",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[factor]\n",
+    "input: output_from(\"projected_sample\"),group_with = \"input_inv\"\n",
+    "output: f'{cwd}/data_preprocessing/{_input_inv[\"Theme\"]}/covariates/{_input:bn}.'\n",
+    "#task: trunk_workers = 1, trunk_size = 1, walltime = '24h',  mem = '40G', tags = f'{step_name}_{_output[0]:bn}'\n",
+    "bash:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
+    "    sos run $[exe_dir]/data_preprocessing/covariate/$[_input_inv[\"factor_analysis_opt\"]]_factor.ipynb $[_input_inv[\"factor_analysis_opt\"]] \\\n",
+    "        --molecular_pheno $[_input[1]] \\\n",
+    "        --genotype_list $[_input[0]] \\\n",
+    "        --name $[_input_inv[\"Theme\"]] \\\n",
+    "        --wd $[wd:a]/data_preprocessing/covariate/ \\\n",
+    "        -J 200 -q csg -c $[yml] $[f'--covariate {_input_inv[\"covariate_file\"]}' if os.path.exists(_input_inv[\"covariate_file\"]) else f''] \\\n",
+    "        --container $[container_apex if _input_inv[\"factor_analysis_opt\"] == \"BiCV\" else container_PEER] "
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SoS",
+   "language": "sos",
+   "name": "sos"
+  },
+  "language_info": {
+   "codemirror_mode": "sos",
+   "file_extension": ".sos",
+   "mimetype": "text/x-sos",
+   "name": "sos",
+   "nbconvert_exporter": "sos_notebook.converter.SoS_Exporter",
+   "pygments_lexer": "sos"
+  },
+  "sos": {
+   "kernels": [
+    [
+     "Markdown",
+     "markdown",
+     "markdown",
+     "",
+     ""
+    ],
+    [
+     "SoS",
+     "sos",
+     "",
+     "",
+     "sos"
+    ]
+   ],
+   "version": "0.22.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/code/data_preprocessing/genotype/PCA.ipynb
+++ b/code/data_preprocessing/genotype/PCA.ipynb
@@ -879,7 +879,8 @@
     "parameter: max_axis = \"\"\n",
     "input: plot_data\n",
     "output: f'{cwd}/{_input:bn}.pc.png',\n",
-    "        f'{cwd}/{_input:bn}.scree.png'\n",
+    "        f'{cwd}/{_input:bn}.scree.png',\n",
+    "        f'{cwd}/{_input:bn}.scree.txt'\n",
     "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime, mem = mem, cores = 1, tags = f'{step_name}_{_output[0]:bn}'\n",
     "R: container = container, volumes = [f\"{outlier_file:ad}:{outlier_file:ad}\"], expand = \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'   \n",
     "    library(dplyr)\n",
@@ -960,7 +961,11 @@
     "    cumPVEplot <- qplot(c(1:length(PVE)), cumsum(PVE)) + geom_line() + xlab(\"Principal Component\") + ylab(\"PVE\") + ggtitle(\"Cumulative PVE Plot\") + ylim(0, 1) + scale_x_discrete(limits=factor(1:length(PVE)))\n",
     "    png('${_output[1]}', width = 8, height = 4, unit='in', res=300)\n",
     "    grid.arrange(PVEplot, cumPVEplot, nrow = 1)\n",
-    "    dev.off()"
+    "    dev.off()\n",
+    "    ## Textual Output\n",
+    "    \n",
+    "    PVE_output = tibble(PCs = 1:length(PVE), PVE = PVE, PVE_cum = PVE_cum )\n",
+    "    PVE_output%>%readr::write_delim(${_output[3]:r},\"\\t\")"
    ]
   },
   {

--- a/code/misc/sample_matcher.ipynb
+++ b/code/misc/sample_matcher.ipynb
@@ -141,6 +141,38 @@
     "      --memory ${int(expand_size(mem) * 0.9)/1e6}\n",
     "    rm ${_input[1]}_geno"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "933fbdb7-fea2-4c04-8a37-9400dcc77477",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[filtered_sample_list]\n",
+    "# A genotype fam file\n",
+    "parameter: genoFile = path\n",
+    "# A phenotype file, can be bed.gz or tsv\n",
+    "parameter: phenoFile = path\n",
+    "# Whether the phenoFile sample name was translated into genoFile sample name already.\n",
+    "parameter: translated_phenoFile = False\n",
+    "input: genoFile,phenoFile,sample_lookups\n",
+    "output: ftred_sample_lookups: f'{cwd}/{_input[2]:bn}.filtered.txt'\n",
+    "        ftred_sample_lookups_geno: f'{cwd}/{_input[2]:bn}.filtered_geno.txt'\n",
+    "R: expand = \"$[ ]\", stderr = f'{_output:nn}.stderr', stdout = f'{_output:nn}.stdout', container = container\n",
+    "    library(\"dplyr\")\n",
+    "    library(\"readr\")\n",
+    "    # Read data\n",
+    "    genoFam = read_delim($[_input[1]:ar], \" \", col_names = F)\n",
+    "    phenoFile = read_delim($[_input[1]:ar], \"\\t\", col_names = T)\n",
+    "    sample_lookup = read_delim($[_input[2]:ar], \"\\t\" ,col_names = T)\n",
+    "    ## Get pheno sample list and geno sample list\n",
+    "    sample_lookup = sample_lookup%>%filter( participant_id%in%genoFam$X1,$[f\"participant_id\" if translated_phenoFile else \"sample_id\"]%in%colnames(phenoFile))\n",
+    "    rbind(sample_lookup$participant_id,ample_lookup$participant_id)%>%write_delim($[_output[1]:r],\"\\t\")\n",
+    "    sample_lookup%>%write_delim($[_output[0]:r],\"\\t\")"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
1. Text output for PCA screen plot in  #183 added, cluster plot not added.
2. sample matcher that produce a filtered sample list and a file plink require to filter out samples added 
3. master control of data processing up to the first checkpoint (outlier detection) added.
3.1 Based on 1, added a way to automatically extract number of PCs based on a adjustable cumulative PVE threshold