### PR TITLE
minor bug fix and adjustment on the eqtl_8 tissue analysis

### DIFF
--- a/code/complete_analysis/eQTL_analysis_externalBed.ipynb
+++ b/code/complete_analysis/eQTL_analysis_externalBed.ipynb
@@ -120,7 +120,7 @@
     "    --cwd ./  &\n",
     "\n",
     "\n",
-    "nohup sos run ~/GIT/xqtl-pipeline/code/complete_analysis/eQTL_analysis_externalBed.ipynb factor --recipe /mnt/mfs/statgen/snuc_pseudo_bulk//data/recipe_8tissue \\\n",
+    "nohup sos run ~/GIT/xqtl-pipeline/code/complete_analysis/eQTL_analysis_externalBed.ipynb factor --recipe /mnt/mfs/statgen/snuc_pseudo_bulk//data/recipe_8tissue_new \\\n",
     "    --annotation_gtf /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/data/reference_data/genes.reformatted.gene.gtf --sample_participant_lookup /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/sampleSheetAfterQC.txt -s build &"
    ]
   },

--- a/code/fine_mapping/SuSiE/SuSiE.ipynb
+++ b/code/fine_mapping/SuSiE/SuSiE.ipynb
@@ -392,7 +392,7 @@
     "                                 pip = map_dbl(snps_index,~( susie_list[[i]]$pip[.x])),\n",
     "                                 coef = map_dbl(snps_index,~(coef.susie( susie_list[[i]])[.x+1])))\n",
     "        }\n",
-    "    if(length(susie_tb_ls) > 2){ \n",
+    "    if(length(susie_tb_ls) >= 2){ \n",
     "      for(i in 2:length(susie_tb_ls)){\n",
     "          susie_tb_ls[[i]] = full_join(susie_tb_ls[[i-1]],susie_tb_ls[[i]], by = \"snps\") \n",
     "        }\n",
@@ -418,7 +418,7 @@
     "             effect = snps_tb%>%select(contains(\"coef\"))%>%as.matrix ,\n",
     "             pip = snps_tb%>%select(contains(\"pip\"))%>%as.matrix,\n",
     "             cs = snps_tb%>%select(contains(\"cs\"))%>%as.matrix,\n",
-    "             name = names(susie_list)\n",
+    "             name = names(susie_list))\n",
     "    VariantAnnotation::writeVcf(output_vcf,${_output:nr},index = TRUE)"
    ]
   },
@@ -432,7 +432,7 @@
    "source": [
     "[*_susie_3]\n",
     "input: group_by = \"all\"\n",
-    "output: f'{wd}/{name}.susie.output_list.txt'\n",
+    "output: f'{cwd}/{name}.susie.output_list.txt'\n",
     "python: expand= \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
     "    import pandas as pd\n",
     "    pd.DataFrame({\"output_vcf\" : [$[_input:ar,]]}).to_csv(\"$[_output]\",index = False ,header = False, sep = \"t\")"


### PR DESCRIPTION
1. Some changes was not implemented with the last pr in susie
2. Adjust the input file of the eight tissue analysis so that the duplication snp issue no longer exist
2.1 as it turn out, plink2 remove snps first, then rename the remaining snps, which cause problem with our original input, which still have rsid as snp names. What was changed previously is the related/unrelated/qced plink, but not the original one. Now we have a version that is snp name corrected, duplicated removed, but otherwise raw plink file as our starting point.

New analysis rerunning.