### PR TITLE
Added git to the dockerfile

### DIFF
--- a/container/docker/rna_quantification.dockerfile
+++ b/container/docker/rna_quantification.dockerfile
@@ -7,7 +7,8 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         libbz2-dev \
         libhdf5-dev \
         libncurses5-dev \
-        default-jdk && \
+        default-jdk \
+	git && \
     apt-get clean && \
     apt-get autoremove -y && \
     rm -rf /var/lib/{apt,dpkg,cache,log}/


### PR DESCRIPTION
One of the packages `gffread` requires Git for its installation. I ran into some issues when running this and fixed it by added the `git` package to the apt command and rerunning this.