### PR TITLE
Fixed RSEM indexing issue

### DIFF
--- a/code/data_preprocessing/reference_data.ipynb
+++ b/code/data_preprocessing/reference_data.ipynb
@@ -769,6 +769,7 @@
     "[RSEM_index]\n",
     "parameter: hg_gtf = path\n",
     "parameter: hg_reference = path\n",
+    "parameter: rsem_output_base = f\"{cwd}/RSEM_Index/rsem_reference\"\n",
     "input: hg_reference, hg_gtf\n",
     "output: f\"{cwd}/RSEM_Index/rsem_reference.n2g.idx.fa\", f\"{cwd}/RSEM_Index/rsem_reference.grp\", \n",
     "        f\"{cwd}/RSEM_Index/rsem_reference.idx.fa\", f\"{cwd}/RSEM_Index/rsem_reference.ti\", \n",
@@ -778,7 +779,7 @@
     "bash: container=container, expand= \"${ }\", stderr = f'{_output[0]:d}.stderr', stdout = f'{_output[0]:d}.stdout'\n",
     "    rsem-prepare-reference \\\n",
     "            ${_input[0]} \\\n",
-    "            ${_output:nn} \\\n",
+    "            ${rsem_output_base} \\\n",
     "            --gtf ${_input[1]} \\\n",
     "            --num-threads ${numThreads}"
    ]
@@ -815,7 +816,11 @@
      "sos"
     ]
    ],
-   "version": "0.22.6"
+   "panel": {
+    "displayed": true,
+    "height": 0
+   },
+   "version": "0.22.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The original used all of the outputs as the input for the `rsem-prepare-reference` command which resulted in errors because of too many inputs to the command (`Invalid number of arguments!`). I modified it to use the base of all of the outputs as an input to the `rsem-prepare-function` and left the output variable values as is. The result was a successful run!