### PR TITLE
bug fix on sumstat merger, add genotype to eqtl master control

### DIFF
--- a/code/commands_generator/eQTL_analysis_commands.ipynb
+++ b/code/commands_generator/eQTL_analysis_commands.ipynb
@@ -126,11 +126,18 @@
    },
    "outputs": [],
    "source": [
-    "sos dryrun ~/GIT/xqtl-pipeline/code/complete_analysis/eQTL_analysis_externalBed.ipynb TensorQTL \\\n",
+    "sos dryrun ~/GIT/xqtl-pipeline/pipeline/eQTL_analysis_commands.ipynb TensorQTL \\\n",
     "    --recipe /mnt/mfs/statgen/snuc_pseudo_bulk//data/recipe_8tissue_new     \\\n",
     "    --genotype_list /mnt/mfs/statgen/snuc_pseudo_bulk/data/genotype_qced/plink_files_list.txt      \\\n",
     "    --annotation_gtf /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/genes.reformatted.gene.gtf     \\\n",
-    "    --sample_participant_lookup /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/sampleSheetAfterQC.txt   > Eight_tissue_scripts &"
+    "    --sample_participant_lookup /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/sampleSheetAfterQC.txt   > Eight_tissue_scripts &\n",
+    "\n",
+    "sos dryrun ~/GIT/xqtl-pipeline/pipeline/eQTL_analysis_commands.ipynb plink_per_chrom \\\n",
+    "    --recipe /mnt/mfs/statgen/snuc_pseudo_bulk//data/recipe_8tissue_new     \\\n",
+    "    --ref_fasta /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta    \\\n",
+    "    --genoFile  /mnt/mfs/statgen/snuc_pseudo_bulk/data/genotype_data/GRCh38_liftedover_sorted_all.vcf.gz \\\n",
+    "    --dbSNP_vcf  /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/00-All.vcf.gz \\\n",
+    "    --sample_participant_lookup /mnt/mfs/statgen/snuc_pseudo_bulk/data/reference_data/sampleSheetAfterQC.txt  > genotype_script &"
    ]
   },
   {
@@ -156,7 +163,6 @@
     "parameter: container_TensorQTL = '/mnt/mfs/statgen/containers//TensorQTL.sif'\n",
     "parameter: container_rnaquant = '/mnt/mfs/statgen/containers/rna_quantification.sif'\n",
     "parameter: container_flashpca = '/mnt/mfs/statgen/containers/flashpcaR.sif'\n",
-    "parameter: annotation_gtf = path\n",
     "parameter: sample_participant_lookup = path\n",
     "parameter: phenotype_id_type = \"gene_name\" \n",
     "parameter: yml = path(\"csg.yml\")\n",
@@ -330,6 +336,7 @@
     "[annotation]\n",
     "## Must be ran with internet connection\n",
     "import os\n",
+    "parameter: annotation_gtf = path\n",
     "input: for_each = \"input_inv\"\n",
     "output: f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/phenotype_data/{path(_input_inv[\"molecular_pheno\"]):bn}.bed.gz'\n",
     "report:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
@@ -352,6 +359,7 @@
    "outputs": [],
    "source": [
     "[region_list_generation]\n",
+    "parameter: annotation_gtf = path\n",
     "input: output_from(\"annotation\"), group_with = \"input_inv\"\n",
     "output: pheno_mod = f'{cwd:a}/data_preprocessing/{_input_inv[\"Theme\"]}/phenotype_data/{_input:bnn}.region_list'\n",
     "report:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",

--- a/code/commands_generator/eQTL_analysis_commands.ipynb
+++ b/code/commands_generator/eQTL_analysis_commands.ipynb
@@ -162,7 +162,10 @@
     "parameter: yml = path(\"csg.yml\")\n",
     "import pandas as pd\n",
     "input_inv = pd.read_csv(recipe, sep = \"\\t\").to_dict(\"records\")\n",
-    "import os"
+    "import os\n",
+    "parameter: jobs = 50 # Number of jobs that are submitted to the cluster\n",
+    "parameter: queue = \"csg,q\" # The queue that jobs are submitted to\n",
+    "submission = f'-J {jobs} -c {yml} -q {queue}'"
    ]
   },
   {
@@ -172,7 +175,28 @@
     "kernel": "SoS"
    },
    "source": [
-    "## Molecular Phenotype Calling"
+    "## Data Preprocessing\n",
+    "### Genotype Preprocessing (Once for all tissues)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a933a470-2e1e-4be5-b6a4-7598479e67cf",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[dbSNP]\n",
+    "parameter: dbSNP_vcf = path\n",
+    "input: dbSNP_vcf\n",
+    "output: f'{cwd:a}/{_input:bnn}.add_chr.variants.gz'\n",
+    "report:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "        sos run $[exe_dir]/VCF_QC.ipynb dbsnp_annotate \\\n",
+    "            --genoFile $[_input] \\\n",
+    "            --cwd $[_output:d] \\\n",
+    "            --container $[container_base_bioinfo]  $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -183,7 +207,97 @@
     "kernel": "SoS"
    },
    "outputs": [],
-   "source": []
+   "source": [
+    "[VCF_add_chr]\n",
+    "parameter: genoFile = path\n",
+    "input: genoFile\n",
+    "output: f'{cwd:a}/{_input:bnn}.add_chr.vcf.gz'\n",
+    "report:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "        sos run $[exe_dir]/VCF_QC.ipynb rename_chrs \\\n",
+    "            --genoFile $[_input] \\\n",
+    "            --cwd $[_output:d] \\\n",
+    "            --container $[container_base_bioinfo] \\\n",
+    "            --walltime \"24h\" $[submission if yml.is_file() else \"\" ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68ee4fb6-5aed-4f05-8efd-1496110c2221",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[VCF_QC]\n",
+    "parameter: ref_fasta = path\n",
+    "input: output_from(\"VCF_add_chr\"), output_from(\"dbSNP\")\n",
+    "output: f'{_input:nn}.leftnorm.filtered.bed'\n",
+    "report:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "        sos run $[exe_dir]/VCF_QC.ipynb rename_chrs \\\n",
+    "            --genoFile $[_input[0]] \\\n",
+    "            --dbsnp-variants $[_input[1]]\n",
+    "            --reference-genome $[ref_fasta] \\ \n",
+    "            --cwd $[_output:d] \\\n",
+    "            --container $[container_base_bioinfo] \\\n",
+    "            --walltime \"24h\" $[submission if yml.is_file() else \"\" ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cb9cf57-fcad-4168-b2ae-35d41068d553",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[plink_QC]\n",
+    "# minimum MAF filter to use. 0 means do not apply this filter.\n",
+    "parameter: maf_filter = 0.0\n",
+    "# maximum MAF filter to use. 0 means do not apply this filter.\n",
+    "parameter: maf_max_filter = 0.0\n",
+    "# Maximum missingess per-variant\n",
+    "parameter: geno_filter = 0.1\n",
+    "# Maximum missingness per-sample\n",
+    "parameter: mind_filter = 0.1\n",
+    "# HWE filter \n",
+    "parameter: hwe_filter = 1e-06\n",
+    "input: output_from(\"VCF_QC\")\n",
+    "output: f'{_input:n}.filtered.bed'\n",
+    "report:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "        sos run $[exe_dir]/GWAS_QC.ipynb qc_no_prune \\\n",
+    "            --cwd $[_output:d] \\\n",
+    "            --genoFile $[_input] \\\n",
+    "            --maf-filter $[maf_filter] \\\n",
+    "            --geno-filter $[geno_filter] \\\n",
+    "            --mind-filter $[mind_filter] \\\n",
+    "            --hwe-filter $[hwe_filter]   \\\n",
+    "            --mem 40G  \\\n",
+    "            --container $[container_base_bioinfo]  $[submission if yml.is_file() else \"\" ]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b166a329-38f2-4da4-84cd-c4e0a51c0059",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[plink_per_chrom]\n",
+    "input: output_from(\"plink_QC\")\n",
+    "output: f'{_input:d}/plink_files_list.txt'\n",
+    "report:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
+    "        for i in {1..22} ; do echo chr$i; done > vcf_chr_list\n",
+    "        sos run $[exe_dir]/genotype_formatting.ipynb plink_by_chrom \\\n",
+    "            --genoFile $[_input] \\\n",
+    "            --cwd $[_output:d] \\\n",
+    "            --chrom  `cat vcf_chr_list` \\\n",
+    "            --container $[container_base_bioinfo]  $[submission if yml.is_file() else \"\" ]\n",
+    "        rm vcf_chr_list"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -192,36 +306,16 @@
     "kernel": "SoS",
     "tags": []
    },
-   "source": [
-    "## Data Preprocessing\n",
-    "### Molecular Phenotype Processing"
-   ]
+   "source": []
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "advisory-relationship",
+   "cell_type": "markdown",
+   "id": "9bee5311-3b75-4e5a-9269-716cbfcd901c",
    "metadata": {
     "kernel": "SoS"
    },
-   "outputs": [],
    "source": [
-    "#[Normalization]\n",
-    "#import os\n",
-    "#input: for_each = \"input_inv\"\n",
-    "#skip_if( os.path.exists(_input_inv[\"molecular_pheno\"]))\n",
-    "#output: f'{cwd:a}/data_preprocessing/normalization/{name}.mol_phe.bed.gz'\n",
-    "#bash:  expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout'\n",
-    "#    sos run $[exe_dir]/data_preprocessing/phenotype/GWAS_QC.ipynb output \\\n",
-    "#        --counts_gct $[_input_inv[\"genecount_table\"]] \\\n",
-    "#        --tpm_gct $[_input_inv[\"geneTpm_table\"]] \\\n",
-    "#        --sample_participant_lookup $[_input_inv[\"sample_index\"]] \\\n",
-    "#        --vcf_chr_list $[_input_inv[\"vcf_chr_list\"]] \\\n",
-    "#        --container $[container_gtex] \\\n",
-    "#        --name $[_input_inv[\"Theme\"]] \\\n",
-    "#        --wd $[wd:a]/data_preprocessing/normalization/ \\\n",
-    "#        --container $[container_base_bioinfo] \\\n",
-    "#        -J 200 -q csg -c  $[yml] &"
+    "### Molecular Phenotype Processing"
    ]
   },
   {
@@ -245,7 +339,7 @@
     "    --annotation-gtf $[annotation_gtf] \\\n",
     "    --sample-participant-lookup $[sample_participant_lookup] \\\n",
     "    --container $[container_rnaquant] \\\n",
-    "    --phenotype-id-type $[phenotype_id_type] -J 1 -c $[yml] -q csg"
+    "    --phenotype-id-type $[phenotype_id_type] $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -267,7 +361,7 @@
     "        --annotation-gtf $[annotation_gtf] \\\n",
     "        --sample-participant-lookup $[sample_participant_lookup] \\\n",
     "        --container $[container_rnaquant] \\\n",
-    "        --phenotype-id-type $[phenotype_id_type] -J 1 -c $[yml] -q csg "
+    "        --phenotype-id-type $[phenotype_id_type] $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -288,8 +382,7 @@
     "        --phenoFile $[_input[0]:a] \\\n",
     "        --region-list $[_input[1]:a] \\\n",
     "        --container $[container_rnaquant] \\\n",
-    "        -J 30 -c $[yml] -q csg \\\n",
-    "        --mem 4G "
+    "        --mem 4G      $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -323,7 +416,7 @@
     "        --genoFile $[path(_input_inv[\"genotype_file\"]):n].fam  \\\n",
     "        --sample-participant-lookup $[sample_participant_lookup] \\\n",
     "        --container $[container_rnaquant] \\\n",
-    "        --translated_phenoFile -J 1 -c $[yml] -q csg "
+    "        --translated_phenoFile $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -345,8 +438,8 @@
     "    --genoFile $[_input_inv[\"genotype_file\"]] \\\n",
     "    --name $[_input_inv[\"Theme\"]] \\\n",
     "    --keep-samples $[_input] \\\n",
-    "    --container $[container_base_bioinfo]  -J 1 -c $[yml] -q csg \\\n",
-    "    --walltime 48h -s force "
+    "    --container $[container_base_bioinfo] \\\n",
+    "    --walltime 48h  $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -368,8 +461,8 @@
     "    --genoFile $[_input] \\\n",
     "    --exclude-variants /mnt/mfs/statgen/snuc_pseudo_bulk/Ast/genotype/dupe_snp_to_exclude \\\n",
     "    --maf-filter 0.05 \\\n",
-    "    --container $[container_base_bioinfo] -J 1 -c $[yml] -q csg \\\n",
-    "    --mem 40G  "
+    "    --container $[container_base_bioinfo] \\\n",
+    "    --mem 40G  $[submission if yml.is_file() else \"\" ] "
    ]
   },
   {
@@ -394,8 +487,8 @@
     "    --mind-filter 0.1 \\\n",
     "    --hwe-filter 0 \\\n",
     "    --keep-variants $[_input[1]]  \\\n",
-    "    --container $[container_base_bioinfo] -J 1 -c $[yml] -q csg \\\n",
-    "    --mem 40G  "
+    "    --container $[container_base_bioinfo]  \\\n",
+    "    --mem 40G   $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -425,7 +518,7 @@
     "     sos run $[exe_dir]/pipeline/PCA.ipynb flashpca \\\n",
     "        --cwd $[_output:d] \\\n",
     "        --genoFile $[_input] \\\n",
-    "        --container $[container_flashpca] -J 1 -c $[yml] -q csg  "
+    "        --container $[container_flashpca]  $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -449,7 +542,7 @@
     "            --pca-model  $[_input[1]] \\\n",
     "            --maha-k `awk '$3 < $[PVE_treshold]' $[_input[2]] | tail -1 | cut -f 1  ` \\\n",
     "            --k `awk '$3 < $[PVE_treshold]' $[_input[2]] | tail -1 | cut -f 1 ` \\\n",
-    "            --container $[container_flashpca] -J 1 -c $[yml] -q csg "
+    "            --container $[container_flashpca]  $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -466,11 +559,11 @@
     "output: f'{cwd}/data_preprocessing/{_input_inv[\"Theme\"]}/covariates/{path(_input_inv[\"covariate_file\"]):bn}.pca.cov.gz'\n",
     "report:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
     "    sos run $[exe_dir]/pipeline/covariate_formatting.ipynb merge_pca_covariate \\\n",
-    "    --cwd $[_output:d] \\\n",
-    "    --pcaFile $[_input:a] \\\n",
-    "    --covFile  $[path(_input_inv[\"covariate_file\"])] \\\n",
-    "    --nCov 6  \\\n",
-    "    --container $[container_base_bioinfo] -J 1 -c $[yml] -q csg "
+    "            --cwd $[_output:d] \\\n",
+    "            --pcaFile $[_input:a] \\\n",
+    "            --covFile  $[path(_input_inv[\"covariate_file\"])] \\\n",
+    "            --nCov 6  \\\n",
+    "            --container $[container_base_bioinfo] $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -486,15 +579,15 @@
     "input: output_from(\"merge_pca_covariate\"),output_from(\"annotation\"),group_with = \"input_inv\"\n",
     "output: f'{cwd}/data_preprocessing/{_input_inv[\"Theme\"]}/covariates/{_input[0]:bnn}.BiCV.cov.gz'\n",
     "report:  expand = \"$[ ]\", stderr = f'{_output[0]}.stderr', stdout = f'{_output[0]}.stdout'\n",
-    "     sos run $[exe_dir]/pipeline/BiCV_factor.ipynb BiCV \\\n",
-    "        --cwd $[_output:d] \\\n",
-    "        --phenoFile $[_input[1]:a]  \\\n",
-    "        --covFile  $[_input[0]:a]  \\\n",
-    "        --container $[container_apex]  -J 1 -c $[yml] -q csg \\\n",
-    "        --walltime 24h \\\n",
-    "        --numThreads 8 \\\n",
-    "        --iteration 1000 \\\n",
-    "        --N 60  "
+    "         sos run $[exe_dir]/pipeline/BiCV_factor.ipynb BiCV \\\n",
+    "            --cwd $[_output:d] \\\n",
+    "            --phenoFile $[_input[1]:a]  \\\n",
+    "            --covFile  $[_input[0]:a]  \\\n",
+    "            --container $[container_apex]  \\\n",
+    "            --walltime 24h \\\n",
+    "            --numThreads 8 \\\n",
+    "            --iteration 1000 \\\n",
+    "            --N 60  $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -526,7 +619,7 @@
     "        --molecular_pheno_list $[_input[1]] \\\n",
     "        --covariate $[_input[2]]    \\\n",
     "        --cwd $[_output:d]  \\\n",
-    "        --container $[container_TensorQTL] -J 30 -c csg.yml -q csg  "
+    "        --container $[container_TensorQTL] $[submission if yml.is_file() else \"\" ]"
    ]
   },
   {
@@ -560,7 +653,7 @@
     "        --covFile $[_input[2]]    \\\n",
     "        --cwd $[_output:d] \\\n",
     "        --region-list $[_input[3]] \\\n",
-    "        --container $[container_TensorQTL] -J 30 -c csg.yml -q csg  "
+    "        --container $[container_TensorQTL] $[submission if yml.is_file() else \"\" ]"
    ]
   }
  ],
@@ -595,7 +688,7 @@
      "sos"
     ]
    ],
-   "version": "0.22.9"
+   "version": "0.22.6"
   }
  },
  "nbformat": 4,

--- a/code/misc/summary_stats_merger.ipynb
+++ b/code/misc/summary_stats_merger.ipynb
@@ -366,6 +366,7 @@
     "            #under the same chr:pos or gene:chr:pos. match A0 and A1 by exact, flip, reverse, or flip+reverse.\n",
     "            #if duplicated chr_pos or gene_chr_pos exist, run a recursive match for each pair of them between query and subject.\n",
     "            nq,_ = snps_match(query,subject,keep_ambiguous)\n",
+    "            nq = nq.loc[:,~nq.columns.duplicated()] # Remove duplicated columns due to order of columns difference in subject and query\n",
     "            nqs.append(nq)\n",
     "        if intersect:\n",
     "            #get common snps\n",

--- a/code/misc/summary_stats_merger.ipynb
+++ b/code/misc/summary_stats_merger.ipynb
@@ -434,6 +434,7 @@
     "        fix_header = [\"SNP\",\"A1\",\"A0\",\"POS\",\"CHR\",\"STAT\",\"SE\",\"P\"]\n",
     "        header_list = []\n",
     "        if \"GENE\" in ss_df.columns:\n",
+    "            df['ID'] = ss_df['GENE'] + \":\" + ss_df['SNP']\n",
     "            df['INFO'] = \"GENE=\" + ss_df[\"GENE\"]\n",
     "            fix_header = [\"GENE\",\"SNP\",\"A1\",\"A0\",\"POS\",\"CHR\",\"STAT\",\"SE\",\"P\"]\n",
     "            header_list = ['##INFO=<ID=GENE,Number=1,Type=String,Description=\"The name of genes\">']\n",
@@ -487,7 +488,7 @@
     "    for i in ${_input:r}; do\n",
     "    bgzip -k -f $i \n",
     "    tabix -p vcf -f  $i.gz; done\n",
-    "    bcftools merge ${\" \".join([f'{str(x)}.gz' for x in _input])} --force-samples  -Oz -o ${_output:a}"
+    "    bcftools merge ${\" \".join([f'{str(x)}.gz' for x in _input])} --force-samples -m id  -Oz -o ${_output:a}"
    ]
   }
  ],

--- a/code/misc/yml_generator.ipynb
+++ b/code/misc/yml_generator.ipynb
@@ -14,6 +14,58 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "35176739-d838-4947-b724-493786d4d617",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3d6d4a03-eacc-4667-a959-603e233cf085",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Example target list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3fedc624-c4c8-4385-9ea3-064b609f6972",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "#chr    TARGET\n",
+    "1    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr1.txt\n",
+    "10    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr10.txt\n",
+    "11    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr11.txt\n",
+    "12    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr12.txt\n",
+    "13    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr13.txt\n",
+    "14    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr14.txt\n",
+    "15    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr15.txt\n",
+    "16    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr16.txt\n",
+    "17    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr17.txt\n",
+    "18    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr18.txt\n",
+    "19    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr19.txt\n",
+    "2    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr2.txt\n",
+    "20    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr20.txt\n",
+    "21    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr21.txt\n",
+    "22    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr22.txt\n",
+    "3    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr3.txt\n",
+    "4    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr4.txt\n",
+    "5    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr5.txt\n",
+    "6    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr6.txt\n",
+    "7    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr7.txt\n",
+    "8    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr8.txt\n",
+    "9    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr9.txt"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "id": "premier-uniform",
    "metadata": {
@@ -42,7 +94,7 @@
     "## The target vcf file, with GENE,CHR,POS,A0,A1 as columns, should contains all snps\n",
     "parameter: TARGET_list = path(\"./\")\n",
     "if TARGET_list.is_file():\n",
-    "    TARGET_list = sumstat_list.merge(pd.read_csv(TARGET_list,sep = \"\\t\"), on = \"#chr\" )[[\"TARGET\"]].values.tolist()\n",
+    "    sumstat_inv = sumstat_list.merge(pd.read_csv(TARGET_list,sep = \"\\t\"), on = \"#chr\" )[[\"TARGET\"]].values.tolist()\n",
     "## Assuming all the input sumstat are using the same header\n",
     "parameter: CHR = \"chrom\"\n",
     "parameter: POS = \"pos\"\n",
@@ -67,7 +119,7 @@
    "outputs": [],
    "source": [
     "[yml_generator]\n",
-    "input: for_each  = \"sumstat_inv\",group_with = \"TARGET_list\"\n",
+    "input: for_each  = \"sumstat_inv\"\n",
     "output: f'{cwd:a}/{names}.{_sumstat_inv[0]}/{names}.{_sumstat_inv[0]}.yml'\n",
     "python: expand = \"$[ ]\", stderr = f'{_output}.stderr', stdout = f'{_output}.stdout' , container = container\n",
     "    import os\n",
@@ -75,9 +127,9 @@
     "    import pandas as pd\n",
     "    output = dict()\n",
     "    ## Input dict\n",
-    "    output[\"INPUT\"] = [pd.read_csv(y,\"\\t\",index_col = 0,names = [x],header = 0 ).to_dict() for x,y in zip($[_sumstat_inv[1:len(_sumstat_inv)]],$[sumstat_meta])]       \n",
+    "    output[\"INPUT\"] = [pd.read_csv(y,\"\\t\",index_col = 0,names = [x],header = 0 ).to_dict() for x,y in zip($[_sumstat_inv[1:len(_sumstat_inv)-1]],$[sumstat_meta])]       \n",
     "    ## Target dict\n",
-    "    output[\"TARGET\"] = [\"$[_TARGET_list if _TARGET_list.is_file() else _sumstat_inv[1]]\"] ## Allow for both external TARGET file or using one of the sumstat as TARGET\n",
+    "    output[\"TARGET\"] = [\"$[_sumstat_inv[-1] if TARGET_list.is_file() else _sumstat_inv[1]]\"] ## Allow for both external TARGET file or using one of the sumstat as TARGET\n",
     "    ## Output dict\n",
     "    output[\"OUTPUT\"] = [$[_output:dr]]\n",
     "    with open($[_output:ar], 'w') as f:\n",
@@ -105,60 +157,6 @@
     "for i in theme:\n",
     "    sumstat_list = sumstat_list.assign(**{i : data_dir+ pd.Series([f'/{path(x):b}'  for x in  sumstat_list[i].values.tolist()])  } )\n",
     "sumstat_list.to_csv(_output[1],sep = \"\\t\", index = 0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "sudden-efficiency",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "defined-source",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "59742dd2-2c98-49da-aca8-9e7f0879d177",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "#chr    TARGET\n",
-    "1    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr1.txt\n",
-    "10    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr10.txt\n",
-    "11    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr11.txt\n",
-    "12    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr12.txt\n",
-    "13    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr13.txt\n",
-    "14    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr14.txt\n",
-    "15    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr15.txt\n",
-    "16    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr16.txt\n",
-    "17    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr17.txt\n",
-    "18    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr18.txt\n",
-    "19    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr19.txt\n",
-    "2    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr2.txt\n",
-    "20    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr20.txt\n",
-    "21    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr21.txt\n",
-    "22    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr22.txt\n",
-    "3    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr3.txt\n",
-    "4    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr4.txt\n",
-    "5    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr5.txt\n",
-    "6    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr6.txt\n",
-    "7    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr7.txt\n",
-    "8    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr8.txt\n",
-    "9    /mnt/mfs/statgen/snuc_pseudo_bulk/eight_tissue_analysis/8test/TARGET_ref_chr9.txt"
    ]
   }
  ],


### PR DESCRIPTION
1. Fix a bug in sumstat merger that create duplicates columns in sumstat output, and additional field in VCF sample column, if sumstat and target have different order of columns.
2. Add the genotype section to the eqtl code generator, as discussed.