### PR TITLE
Empty group_by argument and missed string endquote

### DIFF
--- a/code/molecular_phenotypes/calling/RNA_calling.ipynb
+++ b/code/molecular_phenotypes/calling/RNA_calling.ipynb
@@ -947,7 +947,7 @@
     "parameter: max_frag_len = 1000\n",
     "parameter: paired_end = False\n",
     "estimate_rspd = True\n",
-    "input: group_by = , group_with = 'sample_id'\n",
+    "input: group_by = is_paired_end + 1, group_with = 'sample_id'\n",
     "output: f'{cwd}/{_sample_id}.rsem.isoforms.results', f'{cwd}/{_sample_id}.rsem.genes.results'\n",
     "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
     "bash: container=container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
@@ -1045,7 +1045,7 @@
    "source": [
     "[aggregate_picard_rsem_metrics]\n",
     "input: output_from(\"rsem_call_3\") , output_from(\"rnaseqc_call_3\"), group_by = \"all\"\n",
-    "output: f'{cwd}/{samples}.rsem_picard.aggregated_quality.metrics.tsv\n",
+    "output: f'{cwd}/{samples}.rsem_picard.aggregated_quality.metrics.tsv\n'",
     "R: container=container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
     "    ## Define Function\n",
     "    readPicard.alignment_summary_metrics <- function (source) {\n",


### PR DESCRIPTION
These were causing some errors when I tried to run. I replaced the empty `group_by` with `is_paired_end + 1` and fixed the missing end-quote. It is now running fine.