### PR TITLE
Removed redundant hard set of paired end parameter

### DIFF
--- a/code/molecular_phenotypes/calling/RNA_calling.ipynb
+++ b/code/molecular_phenotypes/calling/RNA_calling.ipynb
@@ -976,7 +976,6 @@
     "[rsem_call_3]\n",
     "parameter: RSEM_index = path\n",
     "parameter: max_frag_len = 1000\n",
-    "parameter: paired_end = False\n",
     "# Default empty for unstranded. Options are fr or rf\n",
     "parameter: strand = \"\"\n",
     "estimate_rspd = True\n",
@@ -988,7 +987,7 @@
     "        -o ${_output[0]:d} \\\n",
     "        --max_frag_len ${max_frag_len} \\\n",
     "        --estimate_rspd ${'true' if estimate_rspd else 'false'} \\\n",
-    "        --paired_end ${\"true\" if paired_end else \"false\"} \\\n",
+    "        --paired_end ${\"true\" if is_paired_end else \"false\"} \\\n",
     "        --stranded ${\"true\" if strand else \"false\"} \\\n",
     "        --threads ${numThreads}"
    ]


### PR DESCRIPTION
I noticed I was getting errors when running this pipeline and was getting errors involving paired end reads from RSEM. Looking at the code here it appears that the paired end parameter was statically set as false despite being dynamically defined prior to this. To get around this I deleted the statically defined parameter `paired_end` (since it was redundant as there was already a paired end parameter) and replaced it with the `is_paired_end` parameter.