### PR TITLE
The refactored done and tested.

### DIFF
--- a/code/molecular_phenotypes/calling/RNA_calling.ipynb
+++ b/code/molecular_phenotypes/calling/RNA_calling.ipynb
@@ -207,27 +207,7 @@
     "kernel": "Bash"
    },
    "source": [
-    "To align the reads with STAR."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ba6a64aa-1e0a-46fa-b67d-521f0efd7dab",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "sos run pipeline/RNA_calling.ipynb STAR_align \\\n",
-    "    --cwd output3 \\\n",
-    "    --samples data/sample_fastq.list \\\n",
-    "    --data-dir data \\\n",
-    "    --STAR-index reference_data3/STAR_Index/ \\\n",
-    "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \\\n",
-    "    --container containers/rna_quantification.sif \\\n",
-    "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \\\n",
-    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat -n "
+    "To align the reads with STAR and generate the bam_list recipe for downstream molecular phenotype count matrixes. The `-J 3 -c csg.yml -q csg` part is crucial for it ask for the required memory to conduct the STAR alignment."
    ]
   },
   {
@@ -240,14 +220,14 @@
    "outputs": [],
    "source": [
     "sos run pipeline/RNA_calling.ipynb STAR_output \\\n",
-    "    --cwd output3 \\\n",
+    "    --cwd output4 \\\n",
     "    --samples data/sample_fastq.list \\\n",
     "    --data-dir data \\\n",
     "    --STAR-index reference_data3/STAR_Index/ \\\n",
     "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \\\n",
     "    --container containers/rna_quantification.sif \\\n",
     "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \\\n",
-    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat -s build"
+    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat -s build  -J 3 -c csg.yml -q csg"
    ]
   },
   {
@@ -258,17 +238,7 @@
     "kernel": "Bash"
    },
    "outputs": [],
-   "source": [
-    "sos run pipeline/RNA_calling.ipynb rnaseqc_call \\\n",
-    "    --cwd output4 \\\n",
-    "    --samples data/sample_fastq.list \\\n",
-    "    --data-dir data \\\n",
-    "    --STAR-index reference_data3/STAR_Index/ \\\n",
-    "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \\\n",
-    "    --container containers/rna_quantification.sif \\\n",
-    "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \\\n",
-    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat -s build -J 3 -c csg.yml -q csg"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -277,8 +247,7 @@
     "kernel": "Bash"
    },
    "source": [
-    "To call gene-level RNA expression using `rnaseqc`,\n",
-    "The `-J 3 -c csg.yml -q csg` part is crucial for it ask for the required memory to conduct the STAR alignment."
+    "To call gene-level RNA expression using `rnaseqc`"
    ]
   },
   {
@@ -291,14 +260,15 @@
    "outputs": [],
    "source": [
     "sos run pipeline/RNA_calling.ipynb rnaseqc_call \\\n",
-    "    --cwd output \\\n",
+    "    --cwd output3 \\\n",
     "    --samples data/sample_fastq.list \\\n",
     "    --data-dir data \\\n",
-    "    --STAR-index reference_data/STAR_Index/ \\\n",
-    "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformatted.gene.ERCC.gtf \\\n",
+    "    --STAR-index reference_data3/STAR_Index/ \\\n",
+    "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \\\n",
     "    --container containers/rna_quantification.sif \\\n",
-    "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.ERCC.fasta \\\n",
-    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat "
+    "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \\\n",
+    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat \\\n",
+    "    --bam_list output3/sample_fastq_bam_list -J 3 -c csg.yml -q csg"
    ]
   },
   {
@@ -308,8 +278,7 @@
     "kernel": "Bash"
    },
    "source": [
-    "To call transcript level RNA expression using `RSEM`:\n",
-    "On a cluster, the `--mem 40G -J 3 -c csg.yml -q csg` part is crucial for it ask for the required memory to conduct the STAR alignment. However, while running on local computer, `--mem 40G` will not actually ask for 40G of mem.\n"
+    "To call transcript level RNA expression using `RSEM`:"
    ]
   },
   {
@@ -322,15 +291,16 @@
    "outputs": [],
    "source": [
     "sos run pipeline/RNA_calling.ipynb rsem_call \\\n",
-    "    --cwd output \\\n",
+    "    --cwd output3 \\\n",
     "    --samples data/sample_fastq.list \\\n",
     "    --data-dir data \\\n",
-    "    --STAR-index reference_data/STAR_Index/ \\\n",
+    "    --STAR-index reference_data3/STAR_Index/ \\\n",
     "    --RSEM-index reference_data/RSEM_Index/ \\\n",
-    "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformatted.gene.ERCC.gtf \\\n",
+    "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \\\n",
     "    --container containers/rna_quantification.sif \\\n",
-    "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.ERCC.fasta \\\n",
-    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat  -n"
+    "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \\\n",
+    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat \\\n",
+    "    --bam_list output3/sample_fastq_bam_list -J 3 -c csg.yml -q csg"
    ]
   },
   {
@@ -341,17 +311,7 @@
     "kernel": "Bash"
    },
    "outputs": [],
-   "source": [
-    "sos run pipeline/RNA_calling.ipynb rnaseqc_call \\\n",
-    "    --cwd output \\\n",
-    "    --samples data/sample_fastq.list \\\n",
-    "    --data-dir data \\\n",
-    "    --STAR-index reference_data/STAR_Index/ \\\n",
-    "    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformatted.gene.ERCC.gtf \\\n",
-    "    --container containers/rna_quantification.sif \\\n",
-    "    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.ERCC.fasta \\\n",
-    "    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat -n"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1005,19 +965,7 @@
     "kernel": "SoS"
    },
    "outputs": [],
-   "source": [
-    "[STAR_output]\n",
-    "input: output_from(\"picard_qc\"),  group_by = \"all\"\n",
-    "depends: sos_variable(\"strand\")\n",
-    "output: f'{cwd}/{samples:bn}_bam_list'\n",
-    "import pandas as pd\n",
-    "bam_list = [f'{x:b}' for x in _input[2::4]]\n",
-    "SJ_list = [f'{x:bnnnnn}.SJ.out.tab' for x in _input[2::4]]\n",
-    "print(SJ_list)\n",
-    "print(bam_list)\n",
-    "out = pd.DataFrame({\"sample_id\" : sample_id,\"strand\" : strand , \"bam_list\" : bam_list, \"SJ_list\" :SJ_list  })\n",
-    "out.to_csv(_output,sep = \"\\t\",index = False)"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1062,7 +1010,7 @@
    },
    "outputs": [],
    "source": [
-    "[rnaseqc_call_1, rsem_call_1, picard_qc]\n",
+    "[picard_qc]\n",
     "depends: sos_variable('strand')\n",
     "# Path to flat reference file, for computing QC metric\n",
     "parameter: ref_flat = path\n",
@@ -1158,6 +1106,28 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26edeb27-56e6-4e80-b116-cc913d6fe0e3",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[STAR_output]\n",
+    "input: output_from(\"picard_qc\"),  group_by = \"all\"\n",
+    "depends: sos_variable(\"strand\")\n",
+    "output: f'{cwd}/{samples:bn}_bam_list'\n",
+    "import pandas as pd\n",
+    "coord_bam_list = [f'{x:b}' for x in _input[2::4]]\n",
+    "SJ_list = [f'{x:bnnnnn}.SJ.out.tab' for x in _input[2::4]]\n",
+    "Trans_bam_list = [f'{x:bnnnn}.toTranscriptome.out.bam' for x in _input[2::4]]\n",
+    "print(SJ_list)\n",
+    "out = pd.DataFrame({\"sample_id\" : sample_id,\"strand\" : strand , \"coord_bam_list\" : coord_bam_list, \"SJ_list\" :SJ_list,\"trans_bam_list\" : Trans_bam_list  })\n",
+    "out.to_csv(_output,sep = \"\\t\",index = False)"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "b266d430-2c34-4b13-a816-7729703d3e55",
    "metadata": {
@@ -1181,7 +1151,7 @@
     "\n",
     "### Step Inputs\n",
     "\n",
-    "* `QC_bam`: path to the output in Step 3.\n",
+    "* `bam_list`: path to the output of STAR_output, which outlined the strands and bam file used for each samples.\n",
     "* `gtf`: reference genome `.gtf` file, this gtf file need to have the same chr name format as the index used to generate the bam file and must be on collapsed gene gtf \n",
     "\n",
     "### Step Outputs\n",
@@ -1211,9 +1181,23 @@
    },
    "outputs": [],
    "source": [
-    "[rnaseqc_call_2]\n",
-    "depends: sos_variable('strand')\n",
-    "input: group_by = 4, group_with = {\"sample_id\",\"strand\"}\n",
+    "[rnaseqc_call_1]\n",
+    "import os\n",
+    "import pandas as pd\n",
+    "parameter: bam_list = path\n",
+    "\n",
+    "sample_inv = pd.read_csv(bam_list,\"\\t\")\n",
+    "\n",
+    "## Extract strand information if user have specified the strand\n",
+    "strand = sample_inv.strand.values.tolist()\n",
+    "stop_if(not all([x in [\"fr\", \"rf\", \"unstranded\"] for x in strand ]), msg = \"strand columns should only include ``fr``, ``rf`` or ``unstranded``, please check the bam_list\")     \n",
+    "## Extract sample_id\n",
+    "sample_id = sample_inv.sample_id.values.tolist()\n",
+    "    \n",
+    "## Get the file name for cood_bam data\n",
+    "coord_bam_list_inv = sample_inv.coord_bam_list.values.tolist()\n",
+    "coord_bam_list = [f'{cwd}/{x}' for x in coord_bam_list_inv ]\n",
+    "input:  coord_bam_list, group_by = 1, group_with = {\"sample_id\",\"strand\"}\n",
     "output: f'{cwd}/{_sample_id}.rnaseqc.gene_tpm.gct.gz',\n",
     "        f'{cwd}/{_sample_id}.rnaseqc.gene_reads.gct.gz',\n",
     "        f'{cwd}/{_sample_id}.rnaseqc.exon_reads.gct.gz',\n",
@@ -1223,7 +1207,7 @@
     "    cd ${cwd} && \\\n",
     "    run_rnaseqc.py \\\n",
     "        ${gtf:a} \\\n",
-    "        ${_input[\"md_bam\"]:a} \\\n",
+    "        ${_input:a} \\\n",
     "        ${_sample_id}.rnaseqc \\\n",
     "        -o ./ \\\n",
     "        ${(\"--stranded \" + _strand) if _strand != \"unstranded\" else \"\"}"
@@ -1248,7 +1232,7 @@
    },
    "outputs": [],
    "source": [
-    "[rnaseqc_call_3]\n",
+    "[rnaseqc_call_2]\n",
     "input: group_by = \"all\"\n",
     "output: f'{cwd}/{samples:bn}.rnaseqc.gene_tpm.gct.gz',\n",
     "        f'{cwd}/{samples:bn}.rnaseqc.gene_readsCount.gct.gz',\n",
@@ -1309,6 +1293,7 @@
     "\n",
     "### Step Input\n",
     "\n",
+    "* `bam_list`: path to the output of STAR_output, which outlined the strands and bam file used for each samples.\n",
     "* transcript-level BAM file: path to the output of Step 3.\n",
     "* `RSEM_index`: path to RSEM index\n",
     "\n",
@@ -1325,16 +1310,29 @@
    },
    "outputs": [],
    "source": [
-    "[rsem_call_2]\n",
-    "depends: sos_variable('strand')\n",
+    "[rsem_call_1]\n",
     "parameter: RSEM_index = path\n",
     "parameter: max_frag_len = 1000\n",
     "estimate_rspd = True\n",
-    "input: output_from(\"STAR_align_1\"),  group_by = 2, group_with = {\"sample_id\",\"strand\"} # After star there will only be two output per sample id, regardless of paired/unpaired\n",
+    "\n",
+    "parameter: bam_list = path\n",
+    "\n",
+    "sample_inv = pd.read_csv(bam_list,\"\\t\")\n",
+    "\n",
+    "## Extract strand information if user have specified the strand\n",
+    "strand = sample_inv.strand.values.tolist()\n",
+    "stop_if(not all([x in [\"fr\", \"rf\", \"unstranded\"] for x in strand ]), msg = \"strand columns should only include ``fr``, ``rf`` or ``unstranded``, please check the bam_list\")     \n",
+    "## Extract sample_id\n",
+    "sample_id = sample_inv.sample_id.values.tolist()\n",
+    "    \n",
+    "## Get the file name for trans_bam_list data\n",
+    "trans_bam_list_inv = sample_inv.trans_bam_list.values.tolist()\n",
+    "trans_bam_list = [f'{cwd}/{x}' for x in trans_bam_list_inv ]\n",
+    "input: trans_bam_list ,  group_by = 1, group_with = {\"sample_id\",\"strand\"} \n",
     "output: f'{cwd}/{_sample_id}.rsem.isoforms.results', f'{cwd}/{_sample_id}.rsem.genes.results',f'{cwd}/{_sample_id}.rsem.stat/{_sample_id}.rsem.cnt'\n",
-    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
+    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads, trunk_size = job_size\n",
     "bash: container=container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
-    "    run_RSEM.py ${RSEM_index:a} ${_input[\"trans_bam\"]:a} ${_sample_id} \\\n",
+    "    run_RSEM.py ${RSEM_index:a} ${_input:a} ${_sample_id} \\\n",
     "        -o ${_output[0]:d} \\\n",
     "        --max_frag_len ${max_frag_len} \\\n",
     "        --estimate_rspd ${'true' if estimate_rspd else 'false'} \\\n",
@@ -1362,7 +1360,7 @@
    },
    "outputs": [],
    "source": [
-    "[rsem_call_3]\n",
+    "[rsem_call_2]\n",
     "input: group_by = \"all\"\n",
     "output: f'{cwd}/{samples:bn}.rsem_transcripts_expected_count.txt.gz',\n",
     "        f'{cwd}/{samples:bn}.rsem_transcripts_tpm.txt.gz',\n",
@@ -1372,7 +1370,7 @@
     "        f'{cwd}/{samples:bn}.rsem_genes_tpm.txt.gz',\n",
     "        f'{cwd}/{samples:bn}.rsem_genes_fpkm.txt.gz',\n",
     "        f'{cwd}/{samples:bn}.rsem.aggregated_quality.metrics.tsv'\n",
-    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
+    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads, trunk_size = job_size\n",
     "python: container=container, expand= \"${ }\", stderr = f'{_output[0]:n}.stderr', stdout = f'{_output[0]:n}.stdout'\n",
     "    input_list = [${_input:r,}]\n",
     "    with open('${cwd}/${samples:bn}.rsem.isoforms_output_list', \"w\") as f:\n",
@@ -1457,9 +1455,9 @@
    },
    "outputs": [],
    "source": [
-    "[rsem_call_4,rnaseqc_call_4]\n",
+    "[rsem_call_3,rnaseqc_call_3]\n",
     "output: f'{cwd}/{samples:bn}.multiqc_report.html'\n",
-    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
+    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads, trunk_size = job_size\n",
     "report: output = f\"{_output:n}.multiqc_config.yml\"\n",
     "  extra_fn_clean_exts:\n",
     "      - '_rsem'\n",
@@ -1478,11 +1476,11 @@
    },
    "outputs": [],
    "source": [
-    "[rsem_call_5, rnaseqc_call_5]\n",
+    "[rsem_call_4, rnaseqc_call_4]\n",
     "# Path to flat reference file, for computing QC metric\n",
     "parameter: ref_flat = path\n",
     "output: f'{cwd}/{samples:b}.picard.aggregated_quality.metrics.tsv'\n",
-    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads\n",
+    "task: trunk_workers = 1, walltime = walltime, mem = mem, cores = numThreads, trunk_size = job_size\n",
     "R: container=container, expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout'\n",
     "    ## Define Function\n",
     "    readPicard.alignment_summary_metrics <- function (source) {\n",

--- a/container/singularity/methylation.def
+++ b/container/singularity/methylation.def
@@ -49,6 +49,7 @@ R -e 'BiocManager::install("preprocessCore", configure.args="--disable-threading
 R -e 'BiocManager::install("minfi")'
 R -e 'BiocManager::install("limma")'
 R -e 'BiocManager::install("IlluminaHumanMethylationEPICmanifest")'
+R -e 'BiocManager::install("IlluminaHumanMethylation450kmanifest")'
 R -e 'BiocManager::install("IlluminaHumanMethylationEPICanno.ilm10b4.hg19")'
 R -e "BiocManager::install('achilleasNP/IlluminaHumanMethylationEPICanno.ilm10b5.hg38')"
 


### PR DESCRIPTION
The new procedure will be:
Running 
```
sos run pipeline/RNA_calling.ipynb STAR_output \
    --cwd output3 \
    --samples data/sample_fastq.list \
    --data-dir data \
    --STAR-index reference_data3/STAR_Index/ \
    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \
    --container containers/rna_quantification.sif \
    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \
    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat -s build  -J 3 -c csg.yml -q csg
```
to generate a bam list, which is also the input to leafcutter/psichomic.

Then run:
```
sos run pipeline/RNA_calling.ipynb rnaseqc_call \
    --cwd output3 \
    --samples data/sample_fastq.list \
    --data-dir data \
    --STAR-index reference_data3/STAR_Index/ \
    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \
    --container containers/rna_quantification.sif \
    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \
    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat \
    --bam_list output3/sample_fastq_bam_list -J 3 -c csg.yml -q csg
```

or 

```
sos run pipeline/RNA_calling.ipynb rsem_call \
    --cwd output3 \
    --samples data/sample_fastq.list \
    --data-dir data \
    --STAR-index reference_data3/STAR_Index/ \
    --RSEM-index reference_data/RSEM_Index/ \
    --gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gene.gtf \
    --container containers/rna_quantification.sif \
    --reference-fasta reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy.fasta.fasta \
    --ref-flat reference_data/Homo_sapiens.GRCh38.103.chr.reformated.ERCC.gtf.ref.flat \
    --bam_list output3/sample_fastq_bam_list -J 3 -c csg.yml -q csg
```
with the bam_list option to reload the bam files.

This does not prevent the current issues where STAR_align may be called multiple times. But at least once picard QC was done. We don't need any STAR again. 



