### PR TITLE
Add de-identifying option to xqtl_protocol_demo

### DIFF
--- a/code/xqtl_protocol_demo.ipynb
+++ b/code/xqtl_protocol_demo.ipynb
@@ -8,7 +8,7 @@
     "tags": []
    },
    "source": [
-    "# MWE for eqtl\n",
+    "# xqtl protocol data. for eqtl\n",
     "This serve as a demostration and records of how to generate and what to use the xqtl calling and discovery pipeline. "
    ]
   },
@@ -130,7 +130,6 @@
    },
    "outputs": [],
    "source": [
-    "\n",
     "sos run pipeline/reference_data.ipynb hg_gtf \\\n",
     "    --cwd reference_data \\\n",
     "    --hg-gtf reference_data/Homo_sapiens.GRCh38.103.chr.gtf \\\n",
@@ -257,20 +256,7 @@
     "kernel": "Bash"
    },
    "source": [
-    "To generate SUPPA annotation for psichomics"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9efcc31e-36e0-4577-80d9-c6063f91f626",
-   "metadata": {
-    "kernel": "Bash"
-   },
-   "outputs": [],
-   "source": [
-    "sos run pipeline/reference_data.ipynb SUPPA_annotation \\\n",
-    "    --hg-gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformatted.ERCC.gtf "
+    "To generate ref.flat annotation for picard QC"
    ]
   },
   {
@@ -291,9 +277,9 @@
     "kernel": "SoS"
    },
    "source": [
-    "### Downloading the MWE\n",
+    "### Downloading the data\n",
     "\n",
-    "The samples that we use are the first 50 samples of [This project](https://www.ebi.ac.uk/arrayexpress/experiments/E-GEUV-1/). It should be noted that the ftp server of this project cannot be used due to mismatch between bam and bai file. Each the bam/bai file pairs was downloaded using wget. "
+    "The samples that we use are 49 samples of [ROSMAP dataset](https://www.synapse.org/#!Synapse:syn4164376). The data used in this protocol paper after we processed and de-identified can be found at [here]()"
    ]
   },
   {
@@ -305,7 +291,7 @@
    },
    "outputs": [],
    "source": [
-    "cd /mnt/vast/hpc/csg/xqtl_workflow_testing/finalizing/data/bam"
+    "cd /mnt/vast/hpc/csg/xqtl_workflow_testing/finalizing/ROSMAP_data/bam"
    ]
   },
   {
@@ -317,8 +303,8 @@
    },
    "outputs": [],
    "source": [
-    "for i in `cat 50_samples_links`; do \n",
-    "wget $i $i.bai;\n",
+    "for i in `cat 50_samples_synapse_id`; do \n",
+    "synapse get $i;\n",
     "done"
    ]
   },
@@ -361,40 +347,25 @@
   },
   {
    "cell_type": "markdown",
-   "id": "af993cc8-bab9-42cd-8e3a-c8a03e14dfe8",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "It should be noted that, the generation of STAR Index will take significant amount of time."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5ce565bf-f94c-474d-adcc-cecc62e5f1bd",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "outputs": [],
-   "source": [
-    "To downloads the data:"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "03a61893-30b8-4d94-a13b-2a5de4d8235a",
    "metadata": {
     "kernel": "SoS"
    },
    "source": [
     "\n",
-    "### Preprocessing the MWE\n",
+    "### Preprocessing the xqtl protocol data.\n",
     "\n",
-    "Since we are using the fastq files as starting point of our RNASeq calling pipeline, the phenotype of MWE required some preprocessing. \n",
-    "\n",
+    "Since we are using the fastq files as starting point of our RNASeq calling pipeline, the phenotype of xqtl protocol data required some preprocessing . \n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0988d1a-642e-4608-84f5-fd16edc79642",
+   "metadata": {},
+   "source": [
     "#### Generating the input phenotype data\n",
-    "Command 1 take only the chromosome 21 and 22 from each of the bam file in the desinated diretory, then command 2 changes them into fastq file. Doing so keeps our MWE into a managable size"
+    "Command 1 take only the chromosome 21 and 22 from each of the bam file in the desinated diretory, then command 2 changes them into fastq file. Doing so keeps our xqtl protocol data into a managable size"
    ]
   },
   {
@@ -406,7 +377,10 @@
    },
    "outputs": [],
    "source": [
-    "sos run pipeline/phenotype_formatting.ipynb bam_subsetting  --phenoFile `ls ROSMAP_data/RNASeq/*.bam` --cwd ROSMAP_data/RNASeq/subsetted  --container containers/rna_quantification.sif -J 50 -q csg -c csg.yml"
+    "sos run pipeline/phenotype_formatting.ipynb bam_subsetting  \\\n",
+    "    --phenoFile `ls ROSMAP_data/RNASeq/*.bam` \\\n",
+    "    --cwd ROSMAP_data/RNASeq/subsetted  \\\n",
+    "    --container containers/rna_quantification.sif -J 50 -q csg -c csg.yml"
    ]
   },
   {
@@ -418,29 +392,77 @@
    },
    "outputs": [],
    "source": [
-    "sos run pipeline/phenotype_formatting.ipynb bam_to_fastq  --phenoFile `ls ROSMAP_data/RNASeq/subsetted/*.bam` --cwd ROSMAP_data/RNASeq/subsetted/fastq  --container containers/rna_quantification.sif -J 50 -q csg -c csg.yml"
+    "sos run pipeline/phenotype_formatting.ipynb bam_to_fastq  \\\n",
+    "    --phenoFile `ls ROSMAP_data/RNASeq/subsetted/*.bam` \\\n",
+    "    --cwd ROSMAP_data/RNASeq/fastq  \\\n",
+    "    --container containers/rna_quantification.sif -J 50 -q csg -c csg.yml"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "90246acf-3590-442f-bd8d-c7f1fe20956f",
+   "id": "90bbd523-41aa-4c30-a1fe-9400b4915147",
    "metadata": {
-    "kernel": "SoS"
+    "tags": []
    },
    "source": [
-    "The output are shown as followed."
+    "#### Creation of sample name mapper and masks\n",
+    "To match and de-identified the samples in both Genotype/phenotype, a index file was created with the following codes"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e1611eb-af99-42ae-b361-952eb55b36ab",
+   "id": "718e6fee-ea64-49b3-9be8-ee079f6c3b63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "echo -e \"fq1\\tfq2\" > xqtl_protocol_data_sample_list\n",
+    "paste <(ls *.1.fastq) <(ls *.2.fastq) >> xqtl_protocol_data_sample_list"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "af4641d3-c39a-4766-94a4-520e12382f39",
+   "metadata": {},
+   "source": [
+    "***Following codes are ran in python.***"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b40ecf5-3061-462d-8cad-ee9946cedc1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "a = pd.read_csv(\"xqtl_protocol_data_sample_list\",\"\\t\")\n",
+    "sample_id = [x.split(\".\")[0] for x in a.fq1 ]\n",
+    "b = pd.read_csv(\"filtered_sample_index\",\"\\t\")\n",
+    "c = pd.read_csv(\"ROSMAP_assay_rnaSeq_metadata.csv\",\",\")\n",
+    "a[\"rnaseq_id\"] = sample_id\n",
+    "a.merge(b, on = \"rnaseq_id\")\n",
+    "abc = ab.merge(c, left_on = \"rnaseq_id\", right_on = \"specimenID\")\n",
+    "abc.to_csv(\"../../comprehensive_xqtl_protocol_sample_index.tsv\",\"\\t\",index = False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b0caa533-3237-487d-b16b-927fccd6d1c3",
+   "metadata": {},
+   "source": [
+    "`ROSMAP_assay_rnaSeq_metadata.csv` can be downloaded from [ROSMAP metadata](https://www.synapse.org/#!Synapse:syn21088596) wherease `filtered_sample_index` is an internal file we used to determined which samples to used. For the purpose of deidentifying this file will not be released to the public."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c4034f7e-21c4-4f4c-a641-c48e640cbbde",
    "metadata": {
     "kernel": "SoS"
    },
-   "outputs": [],
    "source": [
-    "ls -lah ROSMAP_data/RNASeq/subsetted*.bam"
+    "#### De-identifing the input phenotype data\n",
+    "In compliance to HIPAA and the regulation on ROSMAP, we need to de-identify the data before releasing them to publics"
    ]
   },
   {
@@ -452,7 +474,21 @@
    },
    "outputs": [],
    "source": [
-    "ls -lah ROSMAP_data/RNASeq/subsetted/fastq/*.fastq"
+    "readarray -t array1 <  <(tail -49 ../../comprehensive_xqtl_protocol_sample_index.tsv | cut -f5)\n",
+    "readarray -t array2 <  <(tail -49 ../../comprehensive_xqtl_protocol_sample_index.tsv | cut -f3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1ae6e213-e783-4365-a009-6d4d56a58ebe",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in ${!array1[*]} ; do mv ${array1[$i]}.subsetted.1.fastq Sample_${array2[$i]}.subsetted.1.fastq   ;done\n",
+    "for i in ${!array1[*]} ; do mv ${array1[$i]}.subsetted.2.fastq Sample_${array2[$i]}.subsetted.2.fastq   ;done\n",
+    "for i in ${!array1[*]} ; do mv ${array1[$i]}.subsetted.1.stderr Sample_${array2[$i]}.subsetted.1.stderr   ;done\n",
+    "for i in ${!array1[*]} ; do mv ${array1[$i]}.subsetted.1.stdout Sample_${array2[$i]}.subsetted.1.stdout   ;done"
    ]
   },
   {
@@ -463,29 +499,28 @@
    },
    "source": [
     "#### Generating the input fastq list\n",
-    "The input of our RNA calling section requirs a list of following format, it was generated manually. We allows 2 optional columns: strand and read_length so that user can specify different stand and read length for each of the samples. However, it is not necessary to include them. Our pipeline can detect the strand based on the output of STAR Alignment "
+    "The input of our RNA calling section requirs a list of following format, it was generated manually. We allows 2 optional columns: strand and read_length so that user can specify different stand and read length for each of the samples. However, it is not necessary to include them. Our pipeline can detect the strand based on the output of STAR Alignment.\n",
+    "\n",
+    "***Following codes are ran in python.***"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "f4b96fd5-87d9-477c-bd99-f0f938f65854",
    "metadata": {
     "kernel": "SoS"
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "ID      fq1     fq2     strand\n",
-      "HG00096.1.M_111124_6\tHG00096.1.M_111124_6.subsetted.1.fastq \tHG00096.1.M_111124_6.subsetted.2.fastq \tstrand_missing \n",
-      "HG00101.1.M_111124_4\tHG00101.1.M_111124_4.subsetted.1.fastq \tHG00101.1.M_111124_4.subsetted.2.fastq \tstrand_missing \n",
-      "HG00104.1.M_111124_5\tHG00104.1.M_111124_5.subsetted.1.fastq \tHG00104.1.M_111124_5.subsetted.2.fastq \tstrand_missing \n"
-     ]
-    }
-   ],
-   "source": []
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "abc = pd.read_csv(\"comprehensive_xqtl_protocol_sample_index.tsv\",\"\\t\",index = False)\n",
+    "abc = abc[[\"sample_id\",\"fq1\",\"fq2\",\"strand\",\"readLength\"]]\n",
+    "abc[\"fq1\"] =  [\".\".join([x] + y.split(\".\")[1:])  for x,y in  zip( abc.sample_id, abc.fq1) ]\n",
+    "abc[\"fq2\"] =  [\".\".join([x] + y.split(\".\")[1:])  for x,y in  zip( abc.sample_id, abc.fq2) ]\n",
+    "abc.colums = [\"ID\",\"fq1\",\"fq2\",\"strand\",\"read_length\"]\n",
+    "abc.to_csv(\"xqtl_protocol_data.fastqlist\",\"\\t\",index = False)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -495,7 +530,19 @@
    },
    "source": [
     "#### Subsetting and Indexing the genotypes\n",
-    "Since we only need 49 samples, we only extract 49 samples from the genotype data"
+    "Since we only use 49 samples, we extract 49 samples from the genotype data to save memory and time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d71aac29-6d35-4d28-8751-0aa9085117e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cd ../\n",
+    "echo -e \"old_name\\tnew_name\" > xqtl_protocol_data_sample_list\n",
+    "paste <(cut -f6 ../comprehensive_xqtl_protocol_data_sample_index.tsv ) <(cut -f1 ../comprehensive_xqtl_protocol_data_sample_index.tsv  ) >> xqtl_protocol_data_sample_mask"
    ]
   },
   {
@@ -507,12 +554,16 @@
    },
    "outputs": [],
    "source": [
-    "bcftools view DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.vcf.gz -S <(cat ../RNASeq/subsetted/fastq/comprehensive_mwe_sample_index.tsv | cut -f6 | tail -49 ) > DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.MWE.vcf\n",
-    "bcftools view DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.vcf.gz -S <(cat ../RNASeq/subsetted/fastq/comprehensive_mwe_sample_index.tsv | cut -f6 | tail -49 ) > DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.MWE.vcf\n",
-    "bgzip DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.MWE.vcf\n",
-    "bgzip DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.MWE.vcf\n",
-    "tabix DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.MWE.vcf.gz\n",
-    "tabix DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.MWE.vcf.gz"
+    "bcftools view DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.vcf.gz -S <(cat ../comprehensive_xqtl_protocol_data_sample_index.tsv | cut -f6 | tail -49 ) | \\\n",
+    "bcftools reheader --samples xqtl_protocol_data_sample_mask  -Oz -o DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.xqtl_protocol_data.vcf\n",
+    "\n",
+    "bcftools view DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.vcf.gz -S <(cat ../comprehensive_xqtl_protocol_data_sample_index.tsv | cut -f6 | tail -49 ) | \\\n",
+    "bcftools reheader --samples xqtl_protocol_data_sample_mask  -Oz -o  DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.xqtl_protocol_data.vcf\n",
+    "\n",
+    "bgzip DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.xqtl_protocol_data.vcf\n",
+    "bgzip DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.xqtl_protocol_data.vcf\n",
+    "tabix DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.xqtl_protocol_data.vcf.gz\n",
+    "tabix DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.xqtl_protocol_data.vcf.gz"
    ]
   },
   {
@@ -644,6 +695,14 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72717f01-ca39-4d89-ae07-f57cbdaa14c1",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "id": "c24b2a91-110e-4c95-b9fa-71aa7c238569",
    "metadata": {
@@ -692,6 +751,14 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6d6056e-1703-472a-92bf-6d654ecf5a26",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
    "cell_type": "markdown",
    "id": "2d994fbc-a506-499f-bc1e-18c42aeb53d9",
    "metadata": {
@@ -725,8 +792,25 @@
     "tags": []
    },
    "source": [
-    "### Preparing of Xqtl Discovery pipeline"
+    "### Preparing of Xqtl Discovery pipeline\n",
+    "The command in the analysis in the xqtl pipeline can be generated with the command generater we provided. The command generator requirs what we called a recipe file. The code to generate it and the recipe we will be using are as followed:"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19d321ff-589b-4dc6-8df5-e37549b258c9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e0f1e28-b54d-4c9c-b4fb-55cd2521eed9",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
@@ -746,7 +830,7 @@
    },
    "source": [
     "### Genotype QC\n",
-    "It will take ~30G of memory and ~10 min to complete the VCF_QC step. "
+    "It will take ~25G of memory and ~5 min to complete the VCF_QC step. "
    ]
   },
   {
@@ -758,10 +842,10 @@
    },
    "outputs": [],
    "source": [
-    "sos run pipeline/VCF_QC.ipynb qc --genoFile ROSMAP_data/Genotype/DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.xqtl_protocol.add_chr.vcf.gz ROSMAP_data/Genotype//DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.xqtl_protocol.add_chr.vcf.gz \\\n",
+    "sos run pipeline/VCF_QC.ipynb qc --genoFile ROSMAP_data/Genotype/DEJ_11898_B01_GRM_WGS_2017-05-15_21.recalibrated_variants.xqtl_protocol_data.add_chr.vcf.gz ROSMAP_data/Genotype//DEJ_11898_B01_GRM_WGS_2017-05-15_22.recalibrated_variants.xqtl_protocol_data.add_chr.vcf.gz \\\n",
     "            --dbsnp-variants reference_data/00-All.add_chr.variants.gz \\\n",
     "            --reference-genome reference_data/GRCh38_full_analysis_set_plus_decoy_hla.noALT_noHLA_noDecoy_ERCC.fasta \\\n",
-    "            --cwd output/genotype --container containers/bioinfo.sif -J 2 -q csg2 -c csg.yml --mem 30G &"
+    "            --cwd output/genotype --container containers/bioinfo.sif -J 2 -q csg2 -c csg.yml --mem 25G &"
    ]
   },
   {
@@ -769,7 +853,7 @@
    "id": "3ae59416-57df-4904-b224-b1a8483a12e9",
    "metadata": {},
    "source": [
-    "Since the genotype data are per chromosome, we will need to merged the output plink file. When the input vcf to VCF_QC, this step can be skipped"
+    "Since the genotype data are per chromosome, we will need to merged the output plink file. When the input vcf to VCF_QC is the whole genome one, this step can be skipped"
    ]
   },
   {
@@ -778,7 +862,20 @@
    "id": "b5ac3a14-f46b-4eda-a9e0-8f05f80899f3",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "sos run pipeline/genotype_formatting.ipynb merge_plink --genoFile `ls output/genotype/*.leftnorm.filtered.bed` \\\n",
+    "            --cwd output/genotype --container containers/bioinfo.sif &"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8f46f31a-2143-4609-860d-2c772bc4589f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sos run pipeline/GWAS_QC.ipynb qc --genoFile "
+   ]
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
After taking a closer look at the codes, as it turned out, the code for de-identifying will not undermine the process of de-identifying as long as we keep the mapper to ourselves, and thus should not be stored elsewhere.