### PR TITLE
Xqtl Reference data standardization fix

### DIFF
--- a/code/data_preprocessing/reference_data.ipynb
+++ b/code/data_preprocessing/reference_data.ipynb
@@ -134,7 +134,7 @@
    },
    "outputs": [],
    "source": [
-    "sos run reference_data.ipynb hg_reference \\\n",
+    "sos run pipeline/reference_data.ipynb hg_reference \\\n",
     "    --cwd reference_data \\\n",
     "    --ercc-reference reference_data/ERCC92.fa \\\n",
     "    --hg-reference reference_data/GRCh38_full_analysis_set_plus_decoy_hla.fa \\\n",


### PR DESCRIPTION
Specified the missing directory of reference_data.ipynb in one code block. 