### PR TITLE
Minor update on two unaddressed problem

### DIFF
--- a/code/misc/summary_stats_standardizer.ipynb
+++ b/code/misc/summary_stats_standardizer.ipynb
@@ -627,7 +627,6 @@
     "parameter: yml_list = path\n",
     "import pandas as pd\n",
     "yml_path = pd.read_csv(yml_list,sep = \"\\t\").values.tolist()\n",
-    "depends: Py_Module('cugg')\n",
     "parameter: TARGET_list = path\n",
     "TARGET_path = pd.read_csv(TARGET_list,sep = \"\\t\")\n",
     "yml_path = pd.read_csv(yml_list,sep = \"\\t\").merge(TARGET_path, on = \"#chr\").values.tolist()\n",

--- a/code/molecular_phenotypes/calling/methylation_calling.ipynb
+++ b/code/molecular_phenotypes/calling/methylation_calling.ipynb
@@ -88,6 +88,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "82d10ee1-2ad9-4d26-8b1d-dc4b5533f64c",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run pipeline/methylation_calling.ipynb minfi \\\n",
+    "    --sample-sheet data/MWE/MWE_Sample_sheet.csv \\\n",
+    "    --container containers/methylation.sif"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "temporal-worse",
    "metadata": {

--- a/container/docker/methylation.dockerfile
+++ b/container/docker/methylation.dockerfile
@@ -45,5 +45,6 @@ RUN R -e 'BiocManager::install("limma")'
 RUN R -e 'BiocManager::install("IlluminaHumanMethylationEPICmanifest")'
 RUN R -e 'BiocManager::install("IlluminaHumanMethylation450kmanifest")'
 RUN R -e 'BiocManager::install("IlluminaHumanMethylationEPICanno.ilm10b4.hg19")'
+RUN R -e 'BiocManager::install("IlluminaHumanMethylation450kanno.ilmn12.hg19")'
 RUN R -e "BiocManager::install('achilleasNP/IlluminaHumanMethylationEPICanno.ilm10b5.hg38')"
 CMD exec /bin/bash exec sh "$@"

--- a/container/singularity/methylation.def
+++ b/container/singularity/methylation.def
@@ -51,7 +51,7 @@ R -e 'BiocManager::install("IlluminaHumanMethylationEPICmanifest")'
 R -e 'BiocManager::install("IlluminaHumanMethylation450kmanifest")'
 R -e 'BiocManager::install("IlluminaHumanMethylationEPICanno.ilm10b4.hg19")'
 R -e "BiocManager::install('achilleasNP/IlluminaHumanMethylationEPICanno.ilm10b5.hg38')"
-
+R -e 'BiocManager::install("IlluminaHumanMethylation450kanno.ilmn12.hg19")'
 
 %runscript
 exec /bin/bash exec /bin/bash exec sh "$@"


### PR DESCRIPTION
1. lack of one annotation package for minfi 450K analysis
2. the Py_module dependency in sumstat_standardizer as outlined in https://github.com/cumc/brain-xqtl-analysis/blob/main/analysis/Zhang_BU/ROSMAP_DLPFC/sQTL/association_scan_sQTL.ipynb