### PR TITLE
simulation_pipeline

### DIFF
--- a/code/fine_mapping/Simulation/Simulation.ipynb
+++ b/code/fine_mapping/Simulation/Simulation.ipynb
@@ -1,0 +1,293 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ae8a823b-fa13-41fb-ba13-ecf52237e4a5",
+   "metadata": {
+    "kernel": "Markdown",
+    "tags": []
+   },
+   "source": [
+    "# Simulate data for fine mapping and colocalization \n",
+    "\n",
+    "The data we are using now is N3finemapping from SuSiER package.\n",
+    "\n",
+    "We generate synthetic outcomes $Y^p$ and $Y^e$ under the multipl-regression model $Y = X b + e,\\ e \\sim N_n(0, \\sigma^2 I_n)$, with assumptions on $b$ specified by two parameters: the LD of the two variants $r$, the proportion of variance in $y$ explained by $X$. Given $r = c(0.1, 0.3, 0.5, 0.7, 0.9)$ and $\\phi = c(0.05, 0.1, 0.2, 0.5, 0.7)$, we simulate $Y^p$ and $Y^e$ as follows.\n",
+    "\n",
+    "1. we simulate two true causal variants in a specific LD $r$ for both $Y^p$ and $Y^e$, where there is one common causal variant (colocalized by both $Y^p$ and $Y^e$) and one each for the unique true causal variant. We first random generate one colocalized causal variant $X_c$ and then random select other two variants $X_p$ and $X_e$ such that $LD \\approx r \\pm 0.01$.\n",
+    "2. We consider the fixed effects for the true causal variants. We set up the true effect sizes of these three causal variants are $b^p_{(c, p)} = (1, 1)$ and $b^e_{(c,e)} = (1, 1)$ because b is not that important with $\\phi$ in our prarameter. (Even when b is large enough, if heritability is low, then its ability to explain variance is still low) Then, for all $j \\not\\in \\mathcal{S}$, set $b^p_j=0$ and $b^e_j=0$. To generate the relative distribution of effect sizes, we put the signs of the $|b_j|$.\n",
+    "3. Set $\\sigma^2$ to achieve the desired proportion of variance explained $\\phi$; specific, we solve for $\\sigma^2$ in $\\phi = \\dfrac{var(Xb)}{\\sigma^2 + var(Xb)}$ by replacing $X$ to $X_e$ and $X_p$ separately.\n",
+    "4. For each $i = 1, \\cdots, n$, draw $Y^e_i \\sim N(X_e b^e, \\sigma_e^2)$ and $Y^p_i \\sim N(X_p b^p, \\sigma_p^2)$."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ced410cf-3b1b-4a68-a902-abba82068a24",
+   "metadata": {
+    "kernel": "SoS",
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "[simulation]\n",
+    "parameter: size = 10\n",
+    "parameter: phi = [0.3, 0.3]\n",
+    "parameter: beta = [1.0,1.0,1.0,1.0]\n",
+    "parameter: r = [0.1, 0.1]\n",
+    "parameter: sign_b = [\"1\", \"1\"]\n",
+    "parameter: cwd = path(\"output\")\n",
+    "parameter: job_size = 1\n",
+    "parameter: walltime = \"5h\"\n",
+    "parameter: mem = \"16G\"\n",
+    "parameter: numThreads = 20\n",
+    "parameter: container = \"\"\n",
+    "output: f'{cwd:a}/simulation_data/samplesize_{size}_heri_{phi[0]}_{phi[1]}_LD_{r[0]}_{r[1]}.simulation.rds'\n",
+    "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output[0]:bn}'\n",
+    "R:  expand = '${ }', stdout = f\"{_output:n}.stdout\", stderr = f\"{_output:n}.stderr\", container = container \n",
+    "    # for LD threshold r, count the number of covariance in list that have difference with r less than 0.01\n",
+    "    get_pool <- function(ls, r){\n",
+    "    ls = abs(ls)\n",
+    "    len = length( which(abs(ls - r) < 0.01) ) \n",
+    "    return(len)\n",
+    "    }\n",
+    "\n",
+    "    simu_data <- function(size, Xe, Xp, r = c(0.1, 0.1), phi = c(0.2, 0.2), beta = c(1,1,1,1), sign_b = c(1, 1)){\n",
+    "      if (ncol(Xe) == ncol(Xp)){\n",
+    "        P = ncol(Xe)\n",
+    "      } else {\n",
+    "        stop(\"Please restrict the genotype for the same P SNPs\")\n",
+    "      }\n",
+    "      LDe = cor(Xe)\n",
+    "      LDp = cor(Xp)\n",
+    "\n",
+    "      # set up the relative distribution of true effect sizes\n",
+    "      if (sign_b[1] > 0 & sign_b[2] > 0){\n",
+    "        be_c = c(1,1) * c(beta[1], beta[2])\n",
+    "        bp_c = c(1,1) * c(beta[3], beta[4])\n",
+    "      } else if (sign_b[1] > 0  & sign_b[2] < 0){\n",
+    "        be_c = c(1,1) * c(beta[1], beta[2])\n",
+    "        bp_c = c(1,-1) * c(beta[3], beta[4])\n",
+    "      } else if (sign_b[1] < 0 & sign_b[2] > 0){\n",
+    "        be_c = c(1,-1) * c(beta[1], beta[2])\n",
+    "        bp_c = c(1,1) * c(beta[3], beta[4])\n",
+    "      } else {\n",
+    "        be_c = c(1,-1) * c(beta[1], beta[2])\n",
+    "        bp_c = c(1,-1) * c(beta[3], beta[4])\n",
+    "      }\n",
+    "      # for one snp, if there are 2 other snp that have LD around (difference less than 0.01), we select it to our pool\n",
+    "      e_num<- mapply(get_pool, asplit(LDe, 2), r[1])\n",
+    "      p_num <- mapply(get_pool, asplit(LDe, 2), r[2])\n",
+    "      e_pool <- which(e_num > 2)\n",
+    "      p_pool <- which(p_num > 2)\n",
+    "      pool <- intersect(e_pool, p_pool)\n",
+    "      output = list()\n",
+    "      Ye_list = list()\n",
+    "      Yp_list = list()\n",
+    "      variant_e = list()\n",
+    "      variant_p = list()\n",
+    "      for (i in c(1:size)){\n",
+    "        n1 = sample(pool, 1)\n",
+    "        lde = abs(LDe[n1, ])\n",
+    "        ldp = abs(LDp[n1, ])\n",
+    "        pos_e = which(abs(lde - r[1]) < 0.05)\n",
+    "        pos_p = which(abs(ldp - r[2]) < 0.05)\n",
+    "        ne = sample(pos_e, 1)\n",
+    "        np = sample(pos_p, 1)\n",
+    "        while (ne == np){\n",
+    "          np = sample(pos_p, 1)\n",
+    "        }\n",
+    "\n",
+    "        # set up the  genotype effect\n",
+    "        be = vector(mode=\"numeric\", length=P)\n",
+    "        be[c(n1,ne)] = be_c\n",
+    "        Xe_c = Xe[, c(n1,ne)]\n",
+    "        mu_e <- Xe_c %*% be_c\n",
+    "        sigma2e <- var(mu_e) * (1-phi[1]) / phi[1]\n",
+    "        Ye <- apply(mu_e, 1, function(mu0) {return(rnorm(1, mu0, sigma2e))})\n",
+    "\n",
+    "        bp = vector(mode=\"numeric\", length=P)\n",
+    "        bp[c(n1,np)] = bp_c\n",
+    "        Xp_c = Xp[, c(n1,np)]\n",
+    "        mu_p <- Xp_c %*% bp_c\n",
+    "        sigma2p <- var(mu_p) * (1-phi[2]) / phi[2]\n",
+    "        Yp <- apply(mu_p, 1, function(mu0) {return(rnorm(1, mu0, sigma2p))})\n",
+    "        Ye_list[[i]] <- Ye\n",
+    "        Yp_list[[i]] <- Yp\n",
+    "        variant_e[[i]] <- c(n1,ne)\n",
+    "        variant_p[[i]] <- c(n1,np)\n",
+    "      }\n",
+    "      # set up the true causal variants based on LD\n",
+    "      output[[\"parameter\"]] = list(\"total_size\" = size,\"r\" = r, \"phi\" = phi, \"beta\" = beta, \"sign_beta\" = sign_b)\n",
+    "      output[[\"X\"]][[\"Xe\"]] = Xe\n",
+    "      output[[\"X\"]][[\"Xp\"]] = Xp\n",
+    "      output[[\"Y\"]] = tibble::tibble(\"Ye\" = Ye_list, \"Yp\" = Yp_list,\n",
+    "                                 \"variant_e\" = variant_e, \"variant_p\" = variant_p)\n",
+    "      return(output)\n",
+    "    }\n",
+    "\n",
+    "    library(susieR)\n",
+    "    data(N3finemapping)\n",
+    "    attach(N3finemapping)\n",
+    "    data <- N3finemapping\n",
+    "    Xmat <- data$X\n",
+    "    pos <- sample(1:nrow(Xmat), 550)\n",
+    "    Xe <- Xmat[pos,]\n",
+    "    pos <- sample(1:nrow(Xmat), 550)\n",
+    "    Xp <- Xmat[pos,]\n",
+    "    data = simu_data(size = ${size}, Xe, Xp, r = c(${paths(r):,}), phi = c(${paths(phi):,}), beta = c(${paths(beta):,}), sign_b = c(${paths(sign_b):,}))\n",
+    "    saveRDS(data, ${_output:r})\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e3cb1c1b-52af-44f4-8b65-23a5a70ae77f",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Example .sh file for generating simulation data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb161367-6e48-4045-9a61-709dd5573adb",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "#!/bin/sh\n",
+    "\n",
+    "module load Singularity\n",
+    "\n",
+    "for r in 0.1 0.3 0.5 0.7 0.9\n",
+    "do\n",
+    "    for phi in 0.05 0.1 0.2 0.5 0.7\n",
+    "    do\n",
+    "        sos run /home/hs3393/coloc/Simulation.ipynb simulation \\\n",
+    "        --cwd /home/hs3393/coloc/simulation \\\n",
+    "        --beta 1.0 1.0 1.0 1.0 \\\n",
+    "        --sign_b 1 1 \\\n",
+    "        --r ${r} ${r} \\\n",
+    "        --phi ${phi} ${phi} \\\n",
+    "        --size 1000 --container /mnt/vast/hpc/csg/molecular_phenotype_calling/eqtl//containers/stephenslab.sif\n",
+    "    done\n",
+    "done"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e34b8d8-2e64-42b5-8674-292259505050",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Generate fine mapping result of simulation data, not finished"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcfdfa7d-66fc-4da7-a1c5-cda307a0e6ff",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[finemap]\n",
+    "parameter: simufile = paths\n",
+    "parameter: cwd = path(\"output\")\n",
+    "parameter: container = \"\"\n",
+    "# For cluster jobs, number commands to run per job\n",
+    "parameter: job_size = 1\n",
+    "# Wall clock time expected\n",
+    "parameter: walltime = \"5h\"\n",
+    "# Memory expected\n",
+    "parameter: mem = \"16G\"\n",
+    "# Number of threads\n",
+    "parameter: numThreads = 20\n",
+    "input: simufile, group_by = 1\n",
+    "output: f\"{cwd}/{_input:bn}.finemap_result.RDS\"\n",
+    "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime, mem = mem, cores = numThreads, tags = f'{step_name}_{_output[0]:bn}'\n",
+    "R:  expand = '${ }', stdout = f\"{_output:n}.stdout\", stderr = f\"{_output:n}.stderr\", container = container \n",
+    "    library(\"dplyr\")\n",
+    "    library(\"tibble\")\n",
+    "    library(\"purrr\")\n",
+    "    library(\"tidyr\")\n",
+    "    library(\"readr\")\n",
+    "    library(\"stringr\")\n",
+    "    library(\"susieR\")\n",
+    "    simu_result = readRDS(\"${_input:a}\")\n",
+    "    for (i in c(1:length(simu_result$Y$Ye))){\n",
+    "    out_e[[i]] <- susie(simu_result$X$Xe, simu_result$Y$Ye[[i]])\n",
+    "    out_p[[i]] <- susie(simu_result$X$Xp, simu_result$Y$Yp[[i]])\n",
+    "    }\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3bc62dbf-609f-4e23-90fc-0fa55f1996cb",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "## Example .sh file for run fine mapping on simulation data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "241a2181-1082-4bfb-b0c8-f8d9e1de9e44",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run /home/hs3393/coloc/Simulation.ipynb finemap \\\n",
+    "    --cwd /home/hs3393/coloc/simulation \\\n",
+    "    --simufile `ls /home/hs3393/coloc/simulation/simulation_data/*.rds` \\\n",
+    "    --container /mnt/vast/hpc/csg/molecular_phenotype_calling/eqtl/containers/stephenslab.sif -n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "SoS",
+   "language": "sos",
+   "name": "sos"
+  },
+  "language_info": {
+   "codemirror_mode": "sos",
+   "file_extension": ".sos",
+   "mimetype": "text/x-sos",
+   "name": "sos",
+   "nbconvert_exporter": "sos_notebook.converter.SoS_Exporter",
+   "pygments_lexer": "sos"
+  },
+  "sos": {
+   "kernels": [
+    [
+     "Markdown",
+     "markdown",
+     "markdown",
+     "",
+     ""
+    ],
+    [
+     "SoS",
+     "sos",
+     "",
+     "",
+     "sos"
+    ]
+   ],
+   "version": "0.23.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
I created the simulation pipeline, the pipeline works well, but I want to discuss some details here. So please note: this is definitely not the final version.

In the prototype, we randomly generate one colocalized causal variant $X_c$ and then randomly select the other two variants $X_p$ and $X_e$ such that $LD \approx r \pm 0.01$. However, there can be variants that are far away but have a high correlation, even if they are not linked. I will later check on what occasions this can happen.

Should we switch our logic -- first choose a block that has a high average LD, then we can define it to be a high LD block, then find $X_p$ in this block, rather than "randomly" select $X_p$ that satisfies $LD \approx r \pm 0.01$. 

I come up with this question when analyzing the simulation result and find some abnormal results, see another pull request for details.