### PR TITLE
accomodation of proteiomics

### DIFF
--- a/code/association_scan/TensorQTL/TensorQTL.ipynb
+++ b/code/association_scan/TensorQTL/TensorQTL.ipynb
@@ -27,9 +27,18 @@
     "## Input\n",
     "\n",
     "- List of molecular phenotype files: a list of `bed.gz` files containing the table for the molecular phenotype. It should have a companion index file in `tbi` format.\n",
+    "\n",
+    "    The header of the bed.gz is per the [TensorQTL](https://github.com/broadinstitute/tensorqtl) convention:\n",
+    "\n",
+    "    >    Phenotypes must be provided in BED format, with a single header line starting with # and the first four columns corresponding to: chr, start, end, phenotype_id, with the remaining columns corresponding to samples (the identifiers must match those in the genotype input). The BED file should specify the center of the cis-window (usually the TSS), with start == end-1.\n",
+    "\n",
+    "\n",
     "- List of genotypes in PLINK binary format (`bed`/`bim`/`fam`) for each chromosome, previously processed through our genotype QC pipelines.\n",
     "- Covariate file, a file with #id + samples name as colnames and each row a covariate: fixed and known covariates as well as hidden covariates recovered from factor analysis.\n",
     "- Optionally, a list of traits (genes, regions of molecular features etc) to analyze.\n",
+    "\n",
+    "    \n",
+    "\n",
     "\n",
     "## Output\n",
     "\n",
@@ -210,7 +219,7 @@
     "    --covariate-file /mnt/vast/hpc/csg/snuc_pseudo_bulk/eight_tissue_analysis/output/data_preprocessing/ALL/covariates/ALL.log2cpm.ALL.covariate.pca.resid.PEER.cov.gz \\\n",
     "    --cwd ./output/trans_tensorQTL/ \\\n",
     "    --region-list /mnt/vast/hpc/csg/snuc_pseudo_bulk/eight_tissue_analysis/reference_data/AD_genes.region_list \\\n",
-    "    --container containers/TensorQTL.sif --MAC 5 --region-name gene_name "
+    "    --container containers/TensorQTL.sif --MAC 5 --region-name ID"
    ]
   },
   {
@@ -554,7 +563,8 @@
     "    trans_df = trans.map_trans(genotype_df, phenotype_df, covariates_df, batch_size=$[batch_size],\n",
     "                           return_sparse=True, return_r2 = True, pval_threshold=$[pval_threshold], maf_threshold=$[maf_threshold])\n",
     "    ## Filter out cis signal\n",
-    "    trans_df = trans.filter_cis(trans_df, phenotype_pos_df.T.to_dict(), variant_df, window=$[window])   \n",
+    "    if $[window] != 0:\n",
+    "        trans_df = trans.filter_cis(trans_df, phenotype_pos_df.T.to_dict(), variant_df, window=$[window])   \n",
     "    ## Permutation\n",
     "    perm_df = trans.map_permutations(genotype_df, covariates_df, batch_size=$[batch_size],\n",
     "                             maf_threshold=$[maf_threshold])\n",
@@ -744,7 +754,7 @@
      "sos"
     ]
    ],
-   "version": "0.22.6"
+   "version": "0.23.4"
   }
  },
  "nbformat": 4,

--- a/code/commands_generator/eQTL_analysis_commands.ipynb
+++ b/code/commands_generator/eQTL_analysis_commands.ipynb
@@ -8,7 +8,7 @@
     "tags": []
    },
    "source": [
-    "# Bulk RNA-seq xQTL analysis\n",
+    "# Univariate xQTL Discovery\n",
     "\n",
     "This notebook provide a command generator on the XQTL workflow so it can automate the work for data preprocessing and association testing on multiple data collection as proposed. This version of command generator is suitable for bed file with sQTL and eQTL, the user should specify the input and the output in a recipe file, as documented below"
    ]
@@ -1092,7 +1092,7 @@
      "sos"
     ]
    ],
-   "version": "0.22.6"
+   "version": "0.23.4"
   }
  },
  "nbformat": 4,

--- a/code/data_preprocessing/genotype/GWAS_QC.ipynb
+++ b/code/data_preprocessing/genotype/GWAS_QC.ipynb
@@ -766,17 +766,21 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "SoS",
-   "language": "sos",
-   "name": "sos"
+   "display_name": "Singularity Susie_rpy2",
+   "language": "python",
+   "name": "rpy2_susie"
   },
   "language_info": {
-   "codemirror_mode": "sos",
-   "file_extension": ".sos",
-   "mimetype": "text/x-sos",
-   "name": "sos",
-   "nbconvert_exporter": "sos_notebook.converter.SoS_Exporter",
-   "pygments_lexer": "sos"
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
   },
   "nbdime-conflicts": {
    "local_diff": [

--- a/code/data_preprocessing/phenotype/gene_annotation.ipynb
+++ b/code/data_preprocessing/phenotype/gene_annotation.ipynb
@@ -94,12 +94,29 @@
    },
    "outputs": [],
    "source": [
-    "sos run gene_annotation.ipynb annotate_coord \\\n",
+    "sos run gene_annotation.ipynb annotate_coord_gene \\\n",
     "    --cwd output \\\n",
     "    --phenoFile data/MWE.pheno_log2cpm.tsv.gz \\\n",
     "    --annotation-gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformatted.gene.ERCC.gtf \\\n",
     "    --sample-participant-lookup data/sampleSheetAfterQC.txt \\\n",
     "    --container container/rna_quantification.sif --phenotype-id-type gene_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b85299e2-20f6-45c3-84f5-58cde3c25e8e",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run pipeline/gene_annotation.ipynb annotate_coord_protein \\\n",
+    "    --cwd output_testing \\\n",
+    "    --phenoFile /mnt/mfs/hgrcgrid/homes/zq2209/WashU_BrainProt_442samples_matrix.csv \\\n",
+    "    --annotation-gtf reference_data/Homo_sapiens.GRCh38.103.chr.reformatted.collapse_only.gene.gtf \\\n",
+    "    --protein_name_index /mnt/vast/hpc/csg/ftp_lisanwanglab_sync/ftp_fgc_xqtl/projects/proteomics/knightadrc-washu/WashU_Brain_Somascan1.3k_FEATUREinfo.csv \\\n",
+    "    --container containers/rna_quantification.sif --phenotype-id-type gene_name -n"
    ]
   },
   {
@@ -259,7 +276,9 @@
    "source": [
     "## Implementation using `pyqtl`\n",
     "\n",
-    "Implementation based on [GTEx pipeline](https://github.com/broadinstitute/gtex-pipeline/blob/master/qtl/src/eqtl_prepare_expression.py)."
+    "Implementation based on [GTEx pipeline](https://github.com/broadinstitute/gtex-pipeline/blob/master/qtl/src/eqtl_prepare_expression.py).\n",
+    "\n",
+    "Following step serves to annotate cood for gene expression file."
    ]
   },
   {
@@ -271,7 +290,7 @@
    },
    "outputs": [],
    "source": [
-    "[annotate_coord]\n",
+    "[annotate_coord_gene]\n",
     "# A file to map sample ID from expression to genotype, must contain two columns, sample_id and participant_id, mapping IDs in the expression files to IDs in the genotype (these can be the same).\n",
     "parameter: sample_participant_lookup = path()\n",
     "input: phenoFile, annotation_gtf\n",
@@ -313,6 +332,98 @@
     "    ### Detect duplicated gene_id\n",
     "    bed_df = prepare_bed(df, bed_template_df).drop(\"gene_name\",axis = 1)\n",
     "    bed_df = bed_df.drop_duplicates(\"gene_id\",keep = False)\n",
+    "    qtl.io.write_bed(bed_df, ${_output:r})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1697bf2c-24ea-40b9-930c-7a6bbbe201d7",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "575459b2-6b12-4305-acf6-e3c0dd6b20d8",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "source": [
+    "Following step serves to annotate cood for proteiomics data. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "21f1dd43-2868-499b-bcf7-6f9f06da5741",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "[annotate_coord_protein]\n",
+    "# A file to map sample ID from expression to genotype, must contain two columns, sample_id and participant_id, mapping IDs in the expression files to IDs in the genotype (these can be the same).\n",
+    "parameter: sample_participant_lookup = path()\n",
+    "parameter: protein_name_index = path()\n",
+    "parameter: protein_ID_type = \"SOMAseqID\"\n",
+    "input: phenoFile, annotation_gtf\n",
+    "output: f'{cwd:a}/{_input[0]:bn}.bed.gz'\n",
+    "task: trunk_workers = 1, trunk_size = job_size, walltime = walltime,  mem = mem, tags = f'{step_name}_{_output:bn}'  \n",
+    "python: expand= \"${ }\", stderr = f'{_output:n}.stderr', stdout = f'{_output:n}.stdout', container = container\n",
+    "\n",
+    "    import pandas as pd\n",
+    "    import qtl.io\n",
+    "    from pathlib import Path\n",
+    "    def prepare_bed(df, bed_template_df, chr_subset=None):\n",
+    "        bed_df = pd.merge(bed_template_df, df, left_index=True, right_index=True)\n",
+    "        # sort by start position\n",
+    "        bed_df = bed_df.groupby('#chr', sort=False, group_keys=False).apply(lambda x: x.sort_values('start'))\n",
+    "        if chr_subset is not None:\n",
+    "            # subset chrs from VCF\n",
+    "            bed_df = bed_df[bed_df.chr.isin(chr_subset)]\n",
+    "        return bed_df\n",
+    "    # Load data\n",
+    "    df = pd.read_csv(${_input[0]:ar}, sep=None , skiprows=0)\n",
+    "    if \"chr\" in df.columns or \"start\" in df.columns or  \"end\" in df.columns:\n",
+    "        df = df.drop([\"chr\", \"start\", \"end\" ])\n",
+    "    protein_ID = df.columns.values[0]\n",
+    "\n",
+    "    protein_name_index = Path(\"${protein_name_index:a}\")\n",
+    "    # For other data please specify a protein ID index\n",
+    "    if protein_name_index.is_file():\n",
+    "        df_info = pd.read_csv(protein_name_index).rename(columns={'${protein_ID_type}': protein_ID, 'EntrezGeneSymbol':'gene_name'})[['gene_name',protein_ID,'UniProt']]\n",
+    "        df = df_info.merge(df, on  = protein_ID)\n",
+    "    else: # For ROSMAP data\n",
+    "        df[['gene_name', 'UniProt']] = df[protein_ID].str.split('|', 1, expand=True)\n",
+    "\n",
+    "\n",
+    "    sample_participant_lookup = Path(\"${sample_participant_lookup:a}\")\n",
+    "\n",
+    "    if \"chr\" in df.columns and \"start\" in df.columns and  \"end\" in df.columns:\n",
+    "        df = df.drop([\"chr\", \"start\", \"end\" ])\n",
+    "    df.set_index( df.columns[0] , inplace=True)\n",
+    "\n",
+    "    # change sample IDs to participant IDs\n",
+    "    if sample_participant_lookup.is_file():\n",
+    "        sample_participant_lookup_s = pd.read_csv(sample_participant_lookup, sep=\"\\t\", index_col=0, dtype={0:str,1:str}, squeeze=True)\n",
+    "        df.rename(columns=sample_participant_lookup_s.to_dict(), inplace=True)\n",
+    "\n",
+    "    if sum(qtl.io.gtf_to_tss_bed(${_input[1]:ar}, feature='gene',phenotype_id = \"gene_id\" ).index.duplicated()) >0:\n",
+    "        raise ValueError(f\"GTF file ${_input[1]:ar} needs to be collapsed into gene model by reference data processing module\")\n",
+    "         \n",
+    "    bed_template_df_id = qtl.io.gtf_to_tss_bed(${_input[1]:ar}, feature='transcript',phenotype_id = \"gene_id\" )\n",
+    "    bed_template_df_name = qtl.io.gtf_to_tss_bed(${_input[1]:ar}, feature='transcript',phenotype_id = \"gene_name\" )\n",
+    "    bed_template_df = bed_template_df_id.merge(bed_template_df_name, on = [\"chr\",\"start\",\"end\"])\n",
+    "    bed_template_df.columns = [\"#chr\",\"start\",\"end\",\"gene_id\",\"gene_name\"]\n",
+    "    bed_template_df = bed_template_df.set_index(\"${phenotype_id_type}\", drop = False )\n",
+    "\n",
+    "    ### Detect duplicated gene_id\n",
+    "    bed_df = prepare_bed(df, bed_template_df)\n",
+    "    bed_df[\"ID\"] = bed_df[\"#chr\"] + \"_\" + bed_df[\"gene_id\"] + \"_\" + bed_df[\"UniProt\"]\n",
+    "    bed_df = bed_df.drop_duplicates(\"ID\",keep = False)[[\"#chr\",\"start\",\"end\",\"ID\"] + df.drop([protein_ID,\"UniProt\"],axis = 1 ).columns.values.tolist()]\n",
     "    qtl.io.write_bed(bed_df, ${_output:r})"
    ]
   },

--- a/code/fine_mapping/SuSiE/SuSiE.ipynb
+++ b/code/fine_mapping/SuSiE/SuSiE.ipynb
@@ -6,18 +6,8 @@
     "kernel": "SoS"
    },
    "source": [
-    "# SuSiE fine-mapping for individual level data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "kernel": "SoS"
-   },
-   "source": [
-    "Pipeline included in this notebook implementas fine-mapping with individual level data using SuSiE model. \n",
-    "\n",
-    "**FIXME: why saying this \"unlike the susie_RSS module, this module perform analysis on 1 of the theme each time\"? we should unify the interfaces if we can (let me try to see why we cannot do that)**"
+    "# Fine-mapping with SuSiE model\n",
+    "This notebook conduct fine_mapping with complete data, unlike the susie_RSS module, this module perform analysis on 1 of the theme each time"
    ]
   },
   {
@@ -222,7 +212,23 @@
     "--cwd output/f_susie_tad_haQTL_pos/ --name haQTL \\\n",
     "--region-list dlpfc_tad_list \\\n",
     "--phenoFile phenotype_list \\\n",
-    "--covFile covar_list --prior mixture_normal_per_scale -J 200 --job_size 2 -c csg.yml -q csg2 -s build  --job_size 1 --mem 35G  &"
+    "--covFile covar_list --prior mixture_normal_per_scale -J 200 --job_size 2 -c csg2.yml -q csg2 -s build  --job_size 1 --mem 35G  &"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run pipeline/SuSiE.ipynb uni_fsusie \\\n",
+    "--genoFile /mnt/vast/hpc/csg/molecular_phenotype_calling/eqtl/output/dlpfc_tad_region_list_plink_files/ROSMAP_NIA_WGS.leftnorm.filtered.filtered.plink_files_list.txt  \\\n",
+    "--cwd output/f_susie_tad_haQTL_pos_check_pure_2/ --name haQTL \\\n",
+    "--region-list dlpfc_tad_list \\\n",
+    "--phenoFile phenotype_list \\\n",
+    "--covFile covar_list --prior mixture_normal_per_scale -J 20 --job_size 2 -c csg2.yml -q csg2 -s build  --job_size 1 --mem 20G --container containers/stephenslab.sif &"
    ]
   },
   {
@@ -258,7 +264,7 @@
     "# Memory expected\n",
     "parameter: mem = \"16G\"\n",
     "# Number of threads\n",
-    "parameter: numThreads = 4\n",
+    "parameter: numThreads = 20\n",
     "trait = pd.read_csv(phenoFile,sep = \"\\t\").tissue\n",
     "# use this function to edit memory string for PLINK input\n",
     "from sos.utils import expand_size"
@@ -583,7 +589,7 @@
     "  \n",
     "  \n",
     "  \n",
-    "    m1 <- multfsusie(Y=list( Y_f = list(Y_resid_new[[1]],Y_resid_new[[3]]) , Y_u= Reduce(cbind, Reduce(cbind,Y_resid_new[c(-1,-3)])),pos = list(pos1 =  phenotype_list$pos[[1]],pos2 =  phenotype_list$pos[[3]]) ,\n",
+    "    m1 <- multfsusie(Y=list( Y_f = list(Y_resid_new[[1]],Y_resid_new[[3]]) , Y_u= Reduce(cbind, Y_resid_new[[2]]),pos = list(pos1 =  phenotype_list$pos[[1]],pos2 =  phenotype_list$pos[[3]]) ,\n",
     "                 X=X ,\n",
     "                 L=20 ,\n",
     "                 data.format=\"list_df\")\n",
@@ -722,7 +728,7 @@
     "    rownames(X) = read.table(text = rownames(X), sep= \":\" )$V2\n",
     "    covar_list = covar_list%>%mutate(covar = map(path, ~read_delim(.x,\"\\t\")%>%select(-`#id`)%>%na.omit%>%t()))\n",
     "    phenotype_list = inner_join(phenotype_list,covar_list, by = \"tissue\")\n",
-    "    phenotype_list = phenotype_list %>% mutate(flag = map(path.x, read_gene_pheno)) %>% dplyr::filter(lengths(flag) >1 ) %>% mutate(Y = map2(path.x,covar, ~read_gene_pheno(.x)%>%select(-c(`#chr`,start,end,gene_id), rownames(.y))%>%t%>%as.matrix))%>%\n",
+    "    phenotype_list = phenotype_list %>% mutate(flag = map(path.x, read_gene_pheno)) %>% dplyr::filter(lengths(flag) >1 ) %>% mutate(Y = map2(path.x,covar, ~read_gene_pheno(.x)%>%select(-c(`#chr`,start,end,${id_name}), rownames(.y))%>%t%>%as.matrix))%>%\n",
     "                                    mutate(covar = map2(covar, Y , ~.x[intersect(.x%>%rownames,rownames(.y)),] ), # add a flag so that those returning NA can be filtered out\n",
     "                                            X_data = map(covar,~X[intersect(rownames(.x),rownames(X)),]),\n",
     "                                            covar = map2(covar, X_data , ~.x[intersect(.x%>%rownames,rownames(.y)),] ),\n",
@@ -1022,7 +1028,7 @@
     "    covar_list = read_delim(\"${_input[1]}\",\"\\t\")\n",
     "    covar_list = covar_list%>%mutate(covar = map(path, ~read_delim(.x,\"\\t\")%>%select(-`#id`)%>%na.omit%>%t()))\n",
     "    phenotype_list = inner_join(phenotype_list,covar_list, by = \"tissue\")\n",
-    "    phenotype_list = phenotype_list%>%mutate(Y = map(path.x, ~read_gene_pheno(.x)%>%select(-c(`#chr`,start,end,gene_id))%>%t%>%as.matrix))%>%mutate(\n",
+    "    phenotype_list = phenotype_list%>%mutate(Y = map(path.x, ~read_gene_pheno(.x)%>%select(-c(`#chr`,start,end,${id_name}))%>%t%>%as.matrix))%>%mutate(\n",
     "                                            #### Get residue for each of tissue\n",
     "                                              Y_resid = map2(Y,covar,~.lm.fit(x = cbind(1,.y), y = .x[rownames(.y),])$residuals%>%t%>%as_tibble))\n",
     "    \n",
@@ -1183,7 +1189,7 @@
      ""
     ]
    ],
-   "version": "0.22.9"
+   "version": "0.23.4"
   }
  },
  "nbformat": 4,

--- a/code/fine_mapping/SuSiE/SuSiE.ipynb
+++ b/code/fine_mapping/SuSiE/SuSiE.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# Fine-mapping with SuSiE model\n",
-    "This notebook conduct fine_mapping with complete data, unlike the susie_RSS module, this module perform analysis on 1 of the theme each time"
+    "This notebook conduct fine_mapping with complete data, unlike the susie_RSS module, this module perform analysis on 1 of the theme each time **FIXME: why saying this \\\"unlike the susie_RSS module, this module perform analysis on 1 of the theme each time\\\"? we should unify the interfaces if we can (let me try to see why we cannot do that)**"
    ]
   },
   {

--- a/code/fine_mapping/SuSiE/SuSiE_post_processing.ipynb
+++ b/code/fine_mapping/SuSiE/SuSiE_post_processing.ipynb
@@ -123,7 +123,52 @@
    "outputs": [],
    "source": [
     "sos run pipeline/SuSiE_post_processing.ipynb fsusie_to_tsv \\\n",
+    "    --cwd output/f_susie_tad_meQTL_pos_2/ --rds_path `ls output/f_susie_tad_meQTL_pos_2//cache/*rds ` \\\n",
+    "    --region-list ../eqtl/dlpfc_tad_list \\\n",
+    "    --container containers/stephenslab.sif -s build"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f643ed2-67cc-4dd1-8442-a93865720c1e",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run pipeline/SuSiE_post_processing.ipynb fsusie_to_tsv \\\n",
     "    --cwd output/f_susie_tad_meQTL_pos/ --rds_path `ls output/f_susie_tad_meQTL_pos//cache/*rds ` \\\n",
+    "    --region-list ../eqtl/dlpfc_tad_list \\\n",
+    "    --container containers/stephenslab.sif -s build"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c5cae21-21df-4b01-a193-524c7620bb11",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run pipeline/SuSiE_post_processing.ipynb fsusie_to_tsv \\\n",
+    "    --cwd output/f_susie_tad_haQTL_pos_check_pure_2 --rds_path `ls output/f_susie_tad_haQTL_pos_check_pure_2/cache/*rds ` \\\n",
+    "    --region-list ../eqtl/dlpfc_tad_list \\\n",
+    "    --container containers/stephenslab.sif -s build"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c0470772-ee61-4e91-9e34-b13670c2b983",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run pipeline/SuSiE_post_processing.ipynb fsusie_to_tsv \\\n",
+    "    --cwd output/f_susie_tad_meQTL_pos_selected/ --rds_path `ls output/f_susie_tad_meQTL_pos//cache/*1201*rds ` \\\n",
     "    --region-list ../eqtl/dlpfc_tad_list \\\n",
     "    --container containers/stephenslab.sif -s build"
    ]
@@ -149,7 +194,20 @@
    "outputs": [],
    "source": [
     "sos run pipeline/SuSiE_post_processing.ipynb susie_overlap_plot \\\n",
-    "    --cwd output/test/ --plot_list plot_recipe --annot_tibble ~/Annotatr_builtin_annotation_tibble.tsv -s force &s"
+    "    --cwd output/test/ --plot_list plot_recipe --annot_tibble ~/Annotatr_builtin_annotation_tibble.tsv -s force &"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7234b425-7b70-4631-9b46-addfda4c66c0",
+   "metadata": {
+    "kernel": "SoS"
+   },
+   "outputs": [],
+   "source": [
+    "sos run pipeline/SuSiE_post_processing.ipynb susie_overlap_plot \\\n",
+    "    --cwd output/test/ --plot_list plot_recipe_1 --annot_tibble ~/Annotatr_builtin_annotation_tibble.tsv -s force &"
    ]
   },
   {
@@ -360,6 +418,9 @@
     "          susie_tb =  susie_tb%>%mutate(  molecular_trait_id = region_list$tad_index,\n",
     "                                 finemapped_region_start = region_list$start,\n",
     "                                 finemapped_region_end = region_list$end)\n",
+    "          if(\"purity\" %in% names(susie_obj)){\n",
+    "              susie_tb = susie_tb%>%mutate(purity = map_dbl(susie_tb$cs_order, ~ifelse(.x%>%as.numeric > 0, susie_obj$purity[[as.numeric(.x)]], NA ) ))\n",
+    "              }\n",
     "    susie_tb = cbind(susie_tb,Reduce(cbind, susie_obj$lBF)%>%as.tibble%>%`colnames<-`(1:length(susie_obj$lBF)))\n",
     "          return(susie_tb)    }\n",
     "    susie_obj = readRDS(\"${_input:a}\")\n",


### PR DESCRIPTION
Many of the problem we observed today is due to the non-standard pre-processing of the proteomics data. Now the proper support for proteomics are added. The gene_annotation notebook, annot_coord_protein step shall generate a bed file with #chr start end ID and sample names as columns, just like all other bed.gz files, with following features:

1. The #chr will have "chr" prefix to the number
2. The ID is in the form of chr_gene.id_uniportID