### PR TITLE
Build containers in GHA

### DIFF
--- a/.github/docker.df
+++ b/.github/docker.df
@@ -1,0 +1,12 @@
+FROM mambaorg/micromamba
+COPY *.yml /environments/
+RUN for yml in $(ls /environments/*.yml); do \
+    env_name=$(grep "name: " < ${yml} | cut -d ' ' --fields 2); \
+        if [ $env_name = "base" ]; then \
+            micromamba install --quiet --yes --name base --file ${yml}; \
+        else \
+            micromamba env create --quiet --yes --file ${yml}; \
+        fi; \
+    done
+RUN micromamba clean --yes
+ENV MAMBA_ACTIVATE_DOCKERFILE=1

--- a/.github/docker.df
+++ b/.github/docker.df
@@ -8,5 +8,5 @@ RUN for yml in $(ls /environments/*.yml); do \
             micromamba env create --quiet --yes --file ${yml}; \
         fi; \
     done
-RUN micromamba clean --yes
+RUN micromamba clean --all --yes
 ENV MAMBA_ACTIVATE_DOCKERFILE=1

--- a/.github/micromamba.def
+++ b/.github/micromamba.def
@@ -1,0 +1,26 @@
+Bootstrap: docker
+From: mambaorg/micromamba
+
+%setup
+    cp *.yml ${SINGULARITY_ROOTFS}
+
+%post
+    for yml in $(ls *.yml); do 
+        env_name=$(grep "name: " < ${yml} | cut -d ' ' --fields 2)
+        if [ $env_name = "base" ]; then
+            micromamba install --quiet --yes --name base --file ${yml}
+        else
+            micromamba env create --quiet --yes --file ${yml};
+        fi
+    done
+    micromamba clean --yes
+    echo 'export MAMBA_DOCKERFILE_ACTIVATE=1' >> ${SINGULARITY_ENVIRONMENT}
+    echo 'export MAMBA_ROOT_PREFIX=/opt/conda' >> ${SINGULARITY_ENVIRONMENT}
+    echo 'export CONDA_ROOT_PREFIX=/opt/conda' >> ${SINGULARITY_ENVIRONMENT}
+
+    cp /bin/bash /bin/bash.orig
+    echo '#!/bin/bash.orig' >> /bin/bash.new
+    echo 'source /usr/local/bin/_activate_current_env.sh' >> /bin/bash.new
+    echo '/bin/bash.orig "$@"' >> /bin/bash.new
+    chmod +x /bin/bash.new
+    mv /bin/bash.new /bin/bash

--- a/.github/micromamba.def
+++ b/.github/micromamba.def
@@ -13,14 +13,7 @@ From: mambaorg/micromamba
             micromamba env create --quiet --yes --file ${yml};
         fi
     done
-    micromamba clean --yes
+    micromamba clean --all --yes
     echo 'export MAMBA_DOCKERFILE_ACTIVATE=1' >> ${SINGULARITY_ENVIRONMENT}
     echo 'export MAMBA_ROOT_PREFIX=/opt/conda' >> ${SINGULARITY_ENVIRONMENT}
     echo 'export CONDA_ROOT_PREFIX=/opt/conda' >> ${SINGULARITY_ENVIRONMENT}
-
-    cp /bin/bash /bin/bash.orig
-    echo '#!/bin/bash.orig' >> /bin/bash.new
-    echo 'source /usr/local/bin/_activate_current_env.sh' >> /bin/bash.new
-    echo '/bin/bash.orig "$@"' >> /bin/bash.new
-    chmod +x /bin/bash.new
-    mv /bin/bash.new /bin/bash

--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -37,9 +37,9 @@ jobs:
         with: 
           base_sha: ${{ steps.last_successful_commit_pull_request.outputs.base }}
           dir_names: true
-          dir_names_exclude_root: true
+          dir_names_exclude_current_dir: true
           json: true
-          files: container/environments/*.yml
+          files: container/environments/*/*.yml
 
       - name: Export changed directories
         id: export-directories

--- a/.github/workflows/container_build.yml
+++ b/.github/workflows/container_build.yml
@@ -1,0 +1,97 @@
+name: Build containers from conda environments
+
+on:
+  pull_request:
+    paths:
+      - '*/*.yml'
+      - '*/*.yaml'
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    outputs:
+      matrix: ${{ steps.export-directories.outputs.matrix }} 
+      any_changed: ${{ steps.changed-directories.outputs.any_changed }}
+
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get branch name
+        id: branch-name
+        uses: tj-actions/branch-names@v7
+
+      - name: Get SHA of last commit to main branch
+        uses: nrwl/nx-set-shas@v3
+        id: last_successful_commit_pull_request
+        with:
+          main-branch-name: ${{ steps.branch-name.outputs.base_ref_branch }} 
+
+      - name: Get changed directories
+        id: changed-directories
+        uses: tj-actions/changed-files@v36
+        with: 
+          base_sha: ${{ steps.last_successful_commit_pull_request.outputs.base }}
+          dir_names: true
+          dir_names_exclude_root: true
+          json: true
+          files: container/environments/*.yml
+
+      - name: Export changed directories
+        id: export-directories
+        run: echo "matrix={\"context\":${{ steps.changed-directories.outputs.all_changed_files }}}" >> "$GITHUB_OUTPUT"
+
+  build_containers:
+    needs: setup
+    if: needs.setup.outputs.any_changed == 'true'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.setup.outputs.matrix) }}
+
+    steps:
+      - name: Checkout pull request branch
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Setup up docker buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Setup micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: containers
+          create-args: apptainer
+          generate-run-shell: true
+
+      - name: Build and export docker containers
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ matrix.context }}
+          file: .github/docker.df
+          tags: ${{ matrix.context }}_docker:latest
+          outputs: type=docker,dest=/tmp/${{ matrix.context }}_docker.tar
+
+      - name: Upload docker containers to GitHub Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.context }}_docker_${{ github.event.pull_request.head.sha }}
+          path: /tmp/${{ matrix.context }}_docker.tar
+
+      - name: Build apptainer containers
+        shell: micromamba-shell {0}
+        run: |
+          pushd ${{ matrix.context}}; \
+            apptainer build /tmp/${{ matrix.context }}_apptainer.sif ${{ github.workspace }}/.github/micromamba.def; \
+          popd
+
+      - name: Upload apptainer containers to GitHub Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.context }}_apptainer_${{ github.event.pull_request.head.sha }}
+          path: /tmp/${{ matrix.context }}_apptainer.sif

--- a/.github/workflows/container_upload.yml
+++ b/.github/workflows/container_upload.yml
@@ -1,0 +1,143 @@
+name: Push containers to GitHub Packages
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  upload_containers:
+    permissions: write-all
+    if: github.event.pull_request.merged == true 
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Download docker containers
+        id: download-docker-containers
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: container_build.yml
+          name: '.*_docker_${{ github.event.pull_request.head.sha }}'
+          name_is_regexp: true
+          path: /tmp/docker_artifacts
+          if_no_artifact_found: warn
+
+      - name: Download apptainer containers
+        id: download-apptainer-containers
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          workflow: container_build.yml
+          name: '.*_apptainer_${{ github.event.pull_request.head.sha }}'
+          name_is_regexp: true
+          path: /tmp/apptainer_artifacts
+          if_no_artifact_found: warn
+
+      - name: Log in to ghcr.io with docker
+        if: steps.download-docker-containers.outputs.found_artifact == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{github.repository_owner}}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push docker containers to ghcr.io
+        if: steps.download-docker-containers.outputs.found_artifact == 'true'
+        run: |
+          find /tmp/docker_artifacts -name *_docker.tar -exec bash -c \
+            'image_name=$(echo $(basename {}) | sed "s/_docker.tar//g") && \
+            docker load --input {} && \
+            docker tag ${image_name}_docker:latest ghcr.io/${{ github.repository_owner }}/${image_name}_docker:latest && \
+            docker push ghcr.io/${{ github.repository_owner }}/${image_name}_docker:latest' \;
+
+      - name: Setup micromamba
+        if: steps.download-apptainer-containers.outputs.found_artifact == 'true'
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-name: containers
+          create-args: apptainer
+          generate-run-shell: true
+      
+      - name: Log in to ghcr.io with apptainer
+        if: steps.download-apptainer-containers.outputs.found_artifact == 'true'
+        shell: micromamba-shell {0}
+        run: |
+          apptainer remote login --username ${{ github.repository_owner }} \
+            --password ${{ secrets.GITHUB_TOKEN }} \
+            docker://ghcr.io/${{ github.repository_owner }}
+
+      - name: Push apptainer containers to ghcr.io
+        if: steps.download-apptainer-containers.outputs.found_artifact == 'true'
+        shell: micromamba-shell {0}
+        run: |
+          find /tmp/apptainer_artifacts -name *_apptainer.sif -exec bash -c \
+            'image_name=$(echo $(basename {}) | sed "s/_apptainer.sif//g") && \
+            apptainer push {} oras://ghcr.io/${{ github.repository_owner }}/${image_name}_apptainer:latest' \;
+
+      - name: Log in to quay.io with docker
+        if: steps.download-docker-containers.outputs.found_artifact == 'true' 
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ vars.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_TOKEN }}
+
+      - name: Push docker containers to quay.io
+        if: steps.download-docker-containers.outputs.found_artifact == 'true'
+        run: |
+          find /tmp/docker_artifacts -name *_docker.tar -exec bash -c \
+            'image_name=$(echo $(basename {}) | sed "s/_docker.tar//g") && \
+            docker load --input {} && \
+            docker tag ${image_name}_docker:latest quay.io/${{ vars.QUAYIO_USERNAME }}/${image_name}_docker:latest && \
+            docker push quay.io/${{ vars.QUAYIO_USERNAME }}/${image_name}_docker:latest' \;
+
+      - name: Log in to quay.io with apptainer
+        if: steps.download-apptainer-containers.outputs.found_artifact == 'true'
+        shell: micromamba-shell {0}
+        run: |
+          apptainer remote login --username ${{ vars.QUAYIO_USERNAME }} \
+            --password ${{ secrets.QUAYIO_TOKEN }} \
+            docker://quay.io/${{ vars.QUAYIO_USERNAME }}
+
+      - name: Push apptainer containers to quay.io
+        if: steps.download-apptainer-containers.outputs.found_artifact == 'true'
+        shell: micromamba-shell {0}
+        run: |
+          find /tmp/apptainer_artifacts -name *_apptainer.sif -exec bash -c \
+            'image_name=$(echo $(basename {}) | sed "s/_apptainer.sif//g") && \
+            apptainer push {} oras://quay.io/${{ vars.QUAYIO_USERNAME }}/${image_name}_apptainer:latest' \;
+
+      - name: Log in to docker.io with docker
+        if: steps.download-docker-containers.outputs.found_artifact == 'true' 
+        uses: docker/login-action@v2
+        with:
+          registry: docker.io
+          username: ${{ vars.DOCKERIO_USERNAME }}
+          password: ${{ secrets.DOCKERIO_TOKEN }}
+
+      - name: Push docker containers to docker.io
+        if: steps.download-docker-containers.outputs.found_artifact == 'true'
+        run: |
+          find /tmp/docker_artifacts -name *_docker.tar -exec bash -c \
+            'image_name=$(echo $(basename {}) | sed "s/_docker.tar//g") && \
+            docker load --input {} && \
+            docker tag ${image_name}_docker:latest docker.io/${{ vars.DOCKERIO_USERNAME }}/${image_name}_docker:latest && \
+            docker push docker.io/${{ vars.DOCKERIO_USERNAME }}/${image_name}_docker:latest' \;
+
+      - name: Log in to docker.io with apptainer
+        if: steps.download-apptainer-containers.outputs.found_artifact == 'true'
+        shell: micromamba-shell {0}
+        run: |
+          apptainer remote login --username ${{ vars.DOCKERIO_USERNAME }} \
+            --password ${{ secrets.DOCKERIO_TOKEN }} \
+            docker://docker.io
+
+      - name: Push apptainer containers to docker.io
+        if: steps.download-apptainer-containers.outputs.found_artifact == 'true'
+        shell: micromamba-shell {0}
+        run: |
+          find /tmp/apptainer_artifacts -name *_apptainer.sif -exec bash -c \
+            'image_name=$(echo $(basename {}) | sed "s/_apptainer.sif//g") && \
+            apptainer push {} oras://docker.io/${{ vars.DOCKERIO_USERNAME }}/${image_name}_apptainer:latest' \;

--- a/container/environments/hello.yml
+++ b/container/environments/hello.yml
@@ -1,0 +1,8 @@
+name: hello
+channels:
+  - dnachun
+  - conda-forge
+  - bioconda
+  - nodefaults
+dependencies:
+  - hello


### PR DESCRIPTION
This PR will add the necessary workflows and other files for us to build our Docker and Apptainer/Singularity containers in GitHub Actions (GHA) runners (Ubuntu VM running in Microsoft Azure) from conda environment YAML files and push the containers to GitHub packages (ghcr.io), quay.io, and DockerHub.

The layout of the workflow is approximately as follows:

`.github/docker.df` - Dockerfile for building a `micromamba`-based Docker container
`.github/apptainer.def` - definition file for building a `micromamba`-based Apptainer/Singularity container
`.github/workflows/container_build.yml` - workflow to build containers with `docker buildx` and `apptainer` and upload the image archive to GHA temporary artifact storage
`.github/workflows/container_upload.yml` - workflow to download containers from GHA artifact storage and tag and upload them to container repositories.